### PR TITLE
📝 docs: add Cursor Cloud specific development instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,11 @@
 - Never commit secrets. Copy `.env.example` → `.env` and set: `WXT_CHROME_APP_CLIENT_ID_PREFIX`, `WXT_WEB_APP_CLIENT_ID_PREFIX`, `WXT_FIREFOX_EXTENSION_ID`.
 - OAuth scopes and IDs are assembled in `wxt.config.ts`; keep published IDs stable.
 
+## Cursor Cloud specific instructions
+
+- **No ESLint/Prettier**: This repo has no linter config. Use `pnpm compile` (TypeScript `--noEmit`) as the primary static check.
+- **Unit tests**: `pnpm test:run` runs Vitest (98 tests across 4 files as of writing). Tests do not require a browser or extension runtime.
+- **Dev server**: `pnpm dev` launches WXT dev mode which builds to `.output/chrome-mv3-dev/` and auto-opens Chrome with the extension loaded. The dev server runs at `http://localhost:3000` and supports hot reload.
+- **Build scripts emit warnings about unapproved build scripts** (`esbuild`, `spawn-sync`). These are non-blocking and can be safely ignored; the build succeeds without approving them.
+- **`postinstall` hook**: `pnpm install` automatically runs `wxt prepare` which generates WXT types in `.wxt/`. If you see missing type errors, re-run `pnpm install`.
+- **`.env` file**: Copy `.env.example` to `.env` before first run. Default OAuth client IDs are baked into `wxt.config.ts` as fallbacks, so the extension works without custom `.env` values.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with practical development environment notes for future Cloud agents.

## Changes

- Added non-obvious caveats about the dev environment:
  - No ESLint/Prettier; `pnpm compile` is the primary static check
  - Unit test runner details (`pnpm test:run` with Vitest)
  - Dev server behavior (`pnpm dev` auto-opens Chrome with extension loaded)
  - Build script warnings about unapproved build scripts (non-blocking)
  - `postinstall` hook runs `wxt prepare` for type generation
  - `.env` file setup with fallback OAuth client IDs

## Verification

All development commands verified:

- `pnpm install` — 590 packages installed successfully
- `pnpm compile` — TypeScript type check passes
- `pnpm test:run` — 98 tests pass across 4 test files
- `pnpm build` — Chrome production build succeeds (1.2 MB total)
- `pnpm dev` — Dev server starts, extension loads in Chrome

## Demo

[demo_quick_prompt_extension.mp4](https://cursor.com/agents/bc-cd15c188-0c8a-4d99-901a-8220df763d3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_quick_prompt_extension.mp4)

Extension loaded in Chrome, created a test prompt, and triggered it via `/p` in Google search.

[Prompt selector triggered via /p in Google search](https://cursor.com/agents/bc-cd15c188-0c8a-4d99-901a-8220df763d3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprompt_selector_triggered.webp)
[Prompt text inserted into search field](https://cursor.com/agents/bc-cd15c188-0c8a-4d99-901a-8220df763d3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprompt_inserted_google.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd15c188-0c8a-4d99-901a-8220df763d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd15c188-0c8a-4d99-901a-8220df763d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

