### PR TITLE
feat: improve attachment upload and image preview UX

### DIFF
--- a/docs/superpowers/plans/2026-04-26-prompt-attachments-webdav.md
+++ b/docs/superpowers/plans/2026-04-26-prompt-attachments-webdav.md
@@ -1184,7 +1184,7 @@ Include in `promptData`:
 attachments,
 ```
 
-Render the editor after notes and before thumbnail URL:
+Render the editor after notes and before prompt source URL:
 
 ```tsx
 <PromptAttachmentEditor

--- a/docs/superpowers/specs/2026-04-26-prompt-attachments-webdav-design.md
+++ b/docs/superpowers/specs/2026-04-26-prompt-attachments-webdav-design.md
@@ -36,7 +36,8 @@ export interface PromptItem {
   notes?: string;
   lastModified?: string;
   sortOrder?: number;
-  thumbnailUrl?: string;
+  promptSourceUrl?: string;
+  promptSourcePreviewDataUrl?: string;
   attachments?: PromptAttachment[];
 }
 ```

--- a/entrypoints/content/components/PromptAttachmentPreview.tsx
+++ b/entrypoints/content/components/PromptAttachmentPreview.tsx
@@ -276,44 +276,44 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
           alt={activeImage.attachment.name}
           className="qp-image-viewer-image"
         />
-        <button
-          type="button"
-          className="qp-image-viewer-close"
-          aria-label={t('closeImagePreview')}
-          onClick={(event) => {
-            event.stopPropagation()
-            setActiveImageId(null)
-          }}
-        >
-          <X aria-hidden="true" />
-        </button>
-        {viewableImages.length > 1 && (
-          <>
-            <button
-              type="button"
-              className="qp-image-viewer-nav qp-image-viewer-prev"
-              aria-label={t('previousImage')}
-              onClick={(event) => {
-                event.stopPropagation()
-                showPreviousImage()
-              }}
-            >
-              <ChevronLeft aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              className="qp-image-viewer-nav qp-image-viewer-next"
-              aria-label={t('nextImage')}
-              onClick={(event) => {
-                event.stopPropagation()
-                showNextImage()
-              }}
-            >
-              <ChevronRight aria-hidden="true" />
-            </button>
-          </>
-        )}
       </div>
+      <button
+        type="button"
+        className="qp-image-viewer-close"
+        aria-label={t('closeImagePreview')}
+        onClick={(event) => {
+          event.stopPropagation()
+          setActiveImageId(null)
+        }}
+      >
+        <X aria-hidden="true" />
+      </button>
+      {viewableImages.length > 1 && (
+        <>
+          <button
+            type="button"
+            className="qp-image-viewer-nav qp-image-viewer-prev"
+            aria-label={t('previousImage')}
+            onClick={(event) => {
+              event.stopPropagation()
+              showPreviousImage()
+            }}
+          >
+            <ChevronLeft aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="qp-image-viewer-nav qp-image-viewer-next"
+            aria-label={t('nextImage')}
+            onClick={(event) => {
+              event.stopPropagation()
+              showNextImage()
+            }}
+          >
+            <ChevronRight aria-hidden="true" />
+          </button>
+        </>
+      )}
     </div>
   ) : null
 

--- a/entrypoints/content/components/PromptAttachmentPreview.tsx
+++ b/entrypoints/content/components/PromptAttachmentPreview.tsx
@@ -249,11 +249,16 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
   return (
     <div ref={containerRef} className="qp-attachments">
       {safeAttachments.map((attachment) => {
+        const isImage = isImageAttachment(attachment)
         const thumbnailUrl = getPreview(attachment)?.thumbnailUrl
 
-        return (
-          <div key={attachment.id} className="qp-attachment">
-            {isImageAttachment(attachment) && thumbnailUrl && (
+        if (isImage) {
+          if (!thumbnailUrl) {
+            return null
+          }
+
+          return (
+            <div key={attachment.id} className="qp-attachment qp-attachment-image-only">
               <button
                 type="button"
                 className="qp-attachment-image-button"
@@ -268,7 +273,12 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
                   decoding="async"
                 />
               </button>
-            )}
+            </div>
+          )
+        }
+
+        return (
+          <div key={attachment.id} className="qp-attachment">
             <div className="qp-attachment-meta">
               <span className="qp-attachment-name">{attachment.name}</span>
               <span className="qp-attachment-size">{formatFileSize(attachment.size)}</span>

--- a/entrypoints/content/components/PromptAttachmentPreview.tsx
+++ b/entrypoints/content/components/PromptAttachmentPreview.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { browser } from '#imports'
 import { ChevronLeft, ChevronRight, X } from 'lucide-react'
 import type { PromptAttachment } from '@/utils/types'
@@ -36,6 +37,7 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
   const [imagePreviews, setImagePreviews] = useState<Record<string, ImagePreviewState>>({})
   const [isPreviewVisible, setIsPreviewVisible] = useState(false)
   const [activeImageId, setActiveImageId] = useState<string | null>(null)
+  const [previewLayerTarget, setPreviewLayerTarget] = useState<Element | DocumentFragment | null>(null)
 
   const getPreview = (attachment: PromptAttachment): ImagePreviewState | undefined => {
     const loadedPreview = imagePreviews[attachment.id]
@@ -124,7 +126,8 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
     }
   }
 
-  const openImageViewer = (attachment: PromptAttachment) => {
+  const openImageViewer = (event: React.MouseEvent, attachment: PromptAttachment) => {
+    event.stopPropagation()
     setActiveImageId(attachment.id)
     void loadFullPreview(attachment)
   }
@@ -144,6 +147,16 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
     setActiveImageId(nextAttachment.id)
     void loadFullPreview(nextAttachment)
   }
+
+  useEffect(() => {
+    const rootNode = containerRef.current?.getRootNode()
+
+    if (typeof ShadowRoot !== 'undefined' && rootNode instanceof ShadowRoot) {
+      setPreviewLayerTarget(rootNode)
+    } else if (typeof document !== 'undefined') {
+      setPreviewLayerTarget(document.body)
+    }
+  }, [])
 
   useEffect(() => {
     const imageAttachments = safeAttachments.filter((attachment) => (
@@ -246,92 +259,108 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({ attac
     return null
   }
 
-  return (
-    <div ref={containerRef} className="qp-attachments">
-      {safeAttachments.map((attachment) => {
-        const isImage = isImageAttachment(attachment)
-        const thumbnailUrl = getPreview(attachment)?.thumbnailUrl
+  const imageViewer = activeImage ? (
+    <div
+      className="qp-image-viewer"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('imagePreviewDialog')}
+      onClick={(event) => {
+        event.stopPropagation()
+        setActiveImageId(null)
+      }}
+    >
+      <div className="qp-image-viewer-inner" onClick={(event) => event.stopPropagation()}>
+        <img
+          src={activeImage.url}
+          alt={activeImage.attachment.name}
+          className="qp-image-viewer-image"
+        />
+        <button
+          type="button"
+          className="qp-image-viewer-close"
+          aria-label={t('closeImagePreview')}
+          onClick={(event) => {
+            event.stopPropagation()
+            setActiveImageId(null)
+          }}
+        >
+          <X aria-hidden="true" />
+        </button>
+        {viewableImages.length > 1 && (
+          <>
+            <button
+              type="button"
+              className="qp-image-viewer-nav qp-image-viewer-prev"
+              aria-label={t('previousImage')}
+              onClick={(event) => {
+                event.stopPropagation()
+                showPreviousImage()
+              }}
+            >
+              <ChevronLeft aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="qp-image-viewer-nav qp-image-viewer-next"
+              aria-label={t('nextImage')}
+              onClick={(event) => {
+                event.stopPropagation()
+                showNextImage()
+              }}
+            >
+              <ChevronRight aria-hidden="true" />
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  ) : null
 
-        if (isImage) {
-          if (!thumbnailUrl) {
-            return null
+  return (
+    <>
+      <div ref={containerRef} className="qp-attachments">
+        {safeAttachments.map((attachment) => {
+          const isImage = isImageAttachment(attachment)
+          const thumbnailUrl = getPreview(attachment)?.thumbnailUrl
+
+          if (isImage) {
+            if (!thumbnailUrl) {
+              return null
+            }
+
+            return (
+              <div key={attachment.id} className="qp-attachment qp-attachment-image-only">
+                <button
+                  type="button"
+                  className="qp-attachment-image-button"
+                  aria-label={attachment.name}
+                  onClick={(event) => openImageViewer(event, attachment)}
+                >
+                  <img
+                    src={thumbnailUrl}
+                    alt={attachment.name}
+                    className="qp-attachment-image"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </button>
+              </div>
+            )
           }
 
           return (
-            <div key={attachment.id} className="qp-attachment qp-attachment-image-only">
-              <button
-                type="button"
-                className="qp-attachment-image-button"
-                aria-label={attachment.name}
-                onClick={() => openImageViewer(attachment)}
-              >
-                <img
-                  src={thumbnailUrl}
-                  alt={attachment.name}
-                  className="qp-attachment-image"
-                  loading="lazy"
-                  decoding="async"
-                />
-              </button>
+            <div key={attachment.id} className="qp-attachment">
+              <div className="qp-attachment-meta">
+                <span className="qp-attachment-name">{attachment.name}</span>
+                <span className="qp-attachment-size">{formatFileSize(attachment.size)}</span>
+              </div>
             </div>
           )
-        }
-
-        return (
-          <div key={attachment.id} className="qp-attachment">
-            <div className="qp-attachment-meta">
-              <span className="qp-attachment-name">{attachment.name}</span>
-              <span className="qp-attachment-size">{formatFileSize(attachment.size)}</span>
-            </div>
-          </div>
-        )
-      })}
-      {activeImage && (
-        <div
-          className="qp-image-viewer"
-          role="dialog"
-          aria-modal="true"
-          aria-label={t('imagePreviewDialog')}
-          onClick={() => setActiveImageId(null)}
-        >
-          <div className="qp-image-viewer-inner" onClick={(event) => event.stopPropagation()}>
-            <img
-              src={activeImage.url}
-              alt={activeImage.attachment.name}
-              className="qp-image-viewer-image"
-            />
-            <button
-              type="button"
-              className="qp-image-viewer-close"
-              aria-label={t('closeImagePreview')}
-              onClick={() => setActiveImageId(null)}
-            >
-              <X aria-hidden="true" />
-            </button>
-            {viewableImages.length > 1 && (
-              <>
-                <button
-                  type="button"
-                  className="qp-image-viewer-nav qp-image-viewer-prev"
-                  aria-label={t('previousImage')}
-                  onClick={showPreviousImage}
-                >
-                  <ChevronLeft aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className="qp-image-viewer-nav qp-image-viewer-next"
-                  aria-label={t('nextImage')}
-                  onClick={showNextImage}
-                >
-                  <ChevronRight aria-hidden="true" />
-                </button>
-              </>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
+        })}
+      </div>
+      {imageViewer && previewLayerTarget ? createPortal(imageViewer, previewLayerTarget) : null}
+    </>
   )
 }
 

--- a/entrypoints/content/components/PromptSelector.tsx
+++ b/entrypoints/content/components/PromptSelector.tsx
@@ -548,7 +548,7 @@ const PromptSelector: React.FC<PromptSelectorProps> = ({
                         )}
                       </button>
                     </div>
-                    <div className={`qp-prompt-body ${prompt.thumbnailUrl ? 'qp-has-thumbnail' : ''}`}>
+                    <div className={`qp-prompt-body ${prompt.promptSourcePreviewDataUrl ? 'qp-has-prompt-source-preview' : ''}`}>
                       <div className="qp-prompt-content">
                         <div className="qp-prompt-preview">{prompt.content}</div>
                         <PromptAttachmentPreview attachments={prompt.attachments} />
@@ -579,14 +579,11 @@ const PromptSelector: React.FC<PromptSelectorProps> = ({
                           )}
                         </div>
                       </div>
-                      {prompt.thumbnailUrl && (
+                      {prompt.promptSourcePreviewDataUrl && (
                         <img
-                          src={prompt.thumbnailUrl}
-                          alt={prompt.title}
-                          className="qp-thumbnail-img"
-                          onError={(e) => {
-                            (e.target as HTMLImageElement).style.display = 'none'
-                          }}
+                          src={prompt.promptSourcePreviewDataUrl}
+                          alt={t('promptSourceUrlPreviewAlt')}
+                          className="qp-prompt-source-preview-img"
                         />
                       )}
                     </div>

--- a/entrypoints/content/utils/styles.ts
+++ b/entrypoints/content/utils/styles.ts
@@ -349,10 +349,11 @@ export function getPromptSelectorStyles(): string {
 
     .qp-image-viewer-close,
     .qp-image-viewer-nav {
-      position: absolute !important;
+      position: fixed !important;
       display: inline-flex !important;
       align-items: center !important;
       justify-content: center !important;
+      z-index: 2147483647 !important;
       width: 40px !important;
       height: 40px !important;
       border: 0 !important;
@@ -375,8 +376,8 @@ export function getPromptSelectorStyles(): string {
     }
 
     .qp-image-viewer-close {
-      top: 8px !important;
-      right: 8px !important;
+      top: 16px !important;
+      right: 16px !important;
     }
 
     .qp-image-viewer-nav {
@@ -385,11 +386,11 @@ export function getPromptSelectorStyles(): string {
     }
 
     .qp-image-viewer-prev {
-      left: 8px !important;
+      left: 16px !important;
     }
 
     .qp-image-viewer-next {
-      right: 8px !important;
+      right: 16px !important;
     }
 
     .qp-image-viewer-close svg,

--- a/entrypoints/content/utils/styles.ts
+++ b/entrypoints/content/utils/styles.ts
@@ -823,14 +823,14 @@ export function getPromptSelectorStyles(): string {
       height: 18px !important;
     }
 
-    /* 缩略图样式 */
+    /* 提示词内容布局 */
     .qp-prompt-body {
       display: flex !important;
       gap: 12px !important;
       align-items: flex-start !important;
     }
 
-    .qp-prompt-body.qp-has-thumbnail {
+    .qp-prompt-body.qp-has-prompt-source-preview {
       justify-content: space-between !important;
     }
 
@@ -839,7 +839,7 @@ export function getPromptSelectorStyles(): string {
       min-width: 0 !important;
     }
 
-    .qp-thumbnail-img {
+    .qp-prompt-source-preview-img {
       width: 36px !important;
       height: 36px !important;
       object-fit: cover !important;

--- a/entrypoints/content/utils/styles.ts
+++ b/entrypoints/content/utils/styles.ts
@@ -281,6 +281,14 @@ export function getPromptSelectorStyles(): string {
       color: var(--qp-text-secondary) !important;
     }
 
+    .qp-attachment.qp-attachment-image-only {
+      max-width: none !important;
+      padding: 0 !important;
+      border: 0 !important;
+      border-radius: 4px !important;
+      background: transparent !important;
+    }
+
     .qp-attachment-image-button {
       appearance: none !important;
       border: 0 !important;
@@ -303,7 +311,7 @@ export function getPromptSelectorStyles(): string {
       height: 72px !important;
       object-fit: cover !important;
       border-radius: 4px !important;
-      border: 1px solid var(--qp-border-color) !important;
+      border: 0 !important;
       flex-shrink: 0 !important;
     }
 

--- a/entrypoints/content/utils/styles.ts
+++ b/entrypoints/content/utils/styles.ts
@@ -313,6 +313,7 @@ export function getPromptSelectorStyles(): string {
       border-radius: 4px !important;
       border: 0 !important;
       flex-shrink: 0 !important;
+      cursor: zoom-in !important;
     }
 
     .qp-image-viewer {

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -9,7 +9,6 @@ import GistIntegrationPage from "./components/GistIntegrationPage";
 import WebDavIntegrationPage from "./components/WebDavIntegrationPage";
 import GlobalSettings from "./components/GlobalSettings";
 import ToastContainer from "./components/ToastContainer";
-import AttachmentStorageGate from "./components/AttachmentStorageGate";
 import "./App.css";
 import "~/assets/tailwind.css";
 import { Button } from "@/components/ui/button";
@@ -78,48 +77,46 @@ const App = () => {
   if (!localeReady) return null;
 
   return (
-    <AttachmentStorageGate translate={t}>
-      <Router>
-        <AppShell>
-          <div className="flex h-screen">
-            <Sidebar />
+    <Router>
+      <AppShell>
+        <div className="flex h-screen">
+          <Sidebar />
 
-            <main className="flex-1 flex flex-col min-w-0 md:relative">
-              <div className="md:hidden h-16 flex-shrink-0 border-b border-border bg-background/95 backdrop-blur" />
+          <main className="flex-1 flex flex-col min-w-0 md:relative">
+            <div className="md:hidden h-16 flex-shrink-0 border-b border-border bg-background/95 backdrop-blur" />
 
-              <div
-                ref={scrollContainerRef}
-                className="thin-scrollbar relative flex-1 overflow-auto bg-background"
-              >
-                <Routes>
-                  <Route path="/" element={<PromptManager />} />
-                  <Route path="/categories" element={<CategoryManager />} />
-                  <Route path="/settings" element={<GlobalSettings />} />
-                  <Route path="/integrations/notion" element={<NotionIntegrationPage />} />
+            <div
+              ref={scrollContainerRef}
+              className="thin-scrollbar relative flex-1 overflow-auto bg-background"
+            >
+              <Routes>
+                <Route path="/" element={<PromptManager />} />
+                <Route path="/categories" element={<CategoryManager />} />
+                <Route path="/settings" element={<GlobalSettings />} />
+                <Route path="/integrations/notion" element={<NotionIntegrationPage />} />
 
-                  <Route path="/integrations/gist" element={<GistIntegrationPage />} />
-                  <Route path="/integrations/webdav" element={<WebDavIntegrationPage />} />
-                </Routes>
+                <Route path="/integrations/gist" element={<GistIntegrationPage />} />
+                <Route path="/integrations/webdav" element={<WebDavIntegrationPage />} />
+              </Routes>
 
-                {showBackToTop && (
-                  <Button
-                    onClick={scrollToTop}
-                    size="icon"
-                    className="fixed bottom-6 right-6 z-[9999] rounded-full shadow-lg"
-                    title={t("backToTop")}
-                    aria-label={t("backToTop")}
-                  >
-                    <ArrowUp className="size-5" />
-                  </Button>
-                )}
+              {showBackToTop && (
+                <Button
+                  onClick={scrollToTop}
+                  size="icon"
+                  className="fixed bottom-6 right-6 z-[9999] rounded-full shadow-lg"
+                  title={t("backToTop")}
+                  aria-label={t("backToTop")}
+                >
+                  <ArrowUp className="size-5" />
+                </Button>
+              )}
 
-                <ToastContainer />
-              </div>
-            </main>
-          </div>
-        </AppShell>
-      </Router>
-    </AttachmentStorageGate>
+              <ToastContainer />
+            </div>
+          </main>
+        </div>
+      </AppShell>
+    </Router>
   );
 };
 

--- a/entrypoints/options/components/CategoryList.tsx
+++ b/entrypoints/options/components/CategoryList.tsx
@@ -111,7 +111,7 @@ const CategoryList = ({
                 }}
                 className={cn(!isSelectable && "invisible")}
               >
-                {t("viewAllCategories")}
+                {t("viewAllPrompts")}
                 <ArrowRight className="size-3.5" />
               </Button>
               <div className="flex items-center gap-1">

--- a/entrypoints/options/components/PromptAttachmentEditor.tsx
+++ b/entrypoints/options/components/PromptAttachmentEditor.tsx
@@ -1,18 +1,22 @@
 import { useRef, useState } from "react";
 import type { ChangeEvent } from "react";
-import { FileText, Loader2, Paperclip, Upload, X } from "lucide-react";
+import { FileText, FolderOpen, HardDrive, Loader2, Paperclip, Upload, X } from "lucide-react";
 
 import type { PromptAttachment } from "@/utils/types";
 import {
   type AttachmentStorageRootHandle,
+  getAttachmentStorageMode,
   getAttachmentRootHandle,
+  pickAndStoreAttachmentRoot,
   removeAttachmentDirectoryFromRoot,
   removeAttachmentFileFromRoot,
+  useInternalAttachmentStorage,
   verifyReadWritePermission,
 } from "@/utils/attachments/fileSystem";
 import {
   buildPromptAttachmentDirectoryPath,
   formatFileSize,
+  isImageAttachment,
 } from "@/utils/attachments/metadata";
 import {
   createAttachmentFromFile,
@@ -20,8 +24,15 @@ import {
 } from "@/utils/attachments/promptAttachmentOperations";
 import type { t as repoTranslate } from "@/utils/i18n";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button, buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface PromptAttachmentEditorProps {
   promptId: string
@@ -46,6 +57,22 @@ const getAttachmentType = (attachment: PromptAttachment): string => {
   return attachment.type || 'application/octet-stream'
 }
 
+const hasAuthorizedAttachmentStorage = async (): Promise<boolean> => {
+  const mode = await getAttachmentStorageMode()
+
+  if (mode === "internal") {
+    return true
+  }
+
+  const root = await getAttachmentRootHandle()
+
+  if (!root) {
+    return false
+  }
+
+  return await verifyReadWritePermission(root)
+}
+
 const PromptAttachmentEditor = ({
   promptId,
   attachments,
@@ -55,6 +82,69 @@ const PromptAttachmentEditor = ({
   const inputRef = useRef<HTMLInputElement>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [isStorageDialogOpen, setIsStorageDialogOpen] = useState(false)
+  const [isCheckingStorage, setIsCheckingStorage] = useState(false)
+  const [isChoosingInternal, setIsChoosingInternal] = useState(false)
+  const [isChoosingExternal, setIsChoosingExternal] = useState(false)
+  const isExternalStorageUnsupported = typeof window.showDirectoryPicker !== "function"
+  const isChoosingStorage = isChoosingInternal || isChoosingExternal
+
+  const openFilePicker = () => {
+    inputRef.current?.click()
+  }
+
+  const handleAddAttachmentClick = async () => {
+    if (busy || isCheckingStorage || isChoosingStorage) return
+
+    setError(null)
+    setIsCheckingStorage(true)
+
+    try {
+      if (await hasAuthorizedAttachmentStorage()) {
+        openFilePicker()
+        return
+      }
+
+      setIsStorageDialogOpen(true)
+    } catch (err) {
+      console.error(translate("attachmentPermissionLost"), err)
+      setIsStorageDialogOpen(true)
+    } finally {
+      setIsCheckingStorage(false)
+    }
+  }
+
+  const chooseInternalStorage = async () => {
+    setError(null)
+    setIsChoosingInternal(true)
+
+    try {
+      await useInternalAttachmentStorage()
+      setIsStorageDialogOpen(false)
+      openFilePicker()
+    } catch (err) {
+      console.error(translate("attachmentStoragePermissionRequired"), err)
+      setError(translate("attachmentStoragePermissionRequired"))
+    } finally {
+      setIsChoosingInternal(false)
+    }
+  }
+
+  const chooseAttachmentDirectory = async () => {
+    setError(null)
+    setIsChoosingExternal(true)
+
+    try {
+      await pickAndStoreAttachmentRoot()
+      setIsStorageDialogOpen(false)
+      openFilePicker()
+    } catch (err) {
+      console.error(translate("attachmentStoragePermissionRequired"), err)
+      setError(translate("attachmentStoragePermissionRequired"))
+    } finally {
+      setIsChoosingExternal(false)
+    }
+  }
 
   const handleFilesSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files || []);
@@ -119,28 +209,99 @@ const PromptAttachmentEditor = ({
           {translate("attachmentsLabel")}
           <span className="font-normal text-muted-foreground">({translate("attachmentsOptional")})</span>
         </label>
-        <label
-          className={cn(
-            buttonVariants({ variant: "outline", size: "sm" }),
-            "cursor-pointer",
-            busy && "pointer-events-none opacity-50",
-          )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAddAttachmentClick}
+          disabled={busy || isCheckingStorage || isChoosingStorage}
         >
-          {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Upload className="size-3.5" />}
+          {busy || isCheckingStorage ? <Loader2 className="size-3.5 animate-spin" /> : <Upload className="size-3.5" />}
           {translate("addAttachment")}
-          <input
-            ref={inputRef}
-            type="file"
-            multiple
-            disabled={busy}
-            aria-label={translate("addAttachment")}
-            onChange={handleFilesSelected}
-            className="hidden"
-          />
-        </label>
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          disabled={busy}
+          aria-label={translate("addAttachment")}
+          onChange={handleFilesSelected}
+          className="hidden"
+        />
       </div>
 
-      {error && (
+      <Dialog open={isStorageDialogOpen} onOpenChange={(open) => {
+        if (!isChoosingStorage) {
+          setIsStorageDialogOpen(open)
+          if (!open) {
+            setError(null)
+          }
+        }
+      }}>
+        <DialogContent className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>{translate("attachmentStorageTitle")}</DialogTitle>
+            <DialogDescription>
+              {translate("attachmentStorageDescription")}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 px-6 pb-6">
+            {error && (
+              <Alert variant="destructive" className="py-3">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            {isExternalStorageUnsupported && (
+              <Alert variant="warning" className="py-3">
+                <AlertDescription>{translate("attachmentStorageUnsupported")}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={chooseAttachmentDirectory}
+                disabled={isExternalStorageUnsupported || isChoosingStorage}
+                className="group flex min-h-40 flex-col items-start rounded-2xl border border-primary/20 bg-primary/5 p-4 text-left shadow-sm transition-all hover:border-primary/35 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+              >
+                <span className="mb-4 flex size-10 items-center justify-center rounded-xl bg-background text-primary shadow-sm ring-1 ring-border">
+                  {isChoosingExternal ? <Loader2 className="size-4 animate-spin" /> : <FolderOpen className="size-4" />}
+                </span>
+                <Badge variant="secondary" className="mb-3 border-primary/15 bg-primary/10 text-primary">
+                  {translate("attachmentStorageRecommended")}
+                </Badge>
+                <span className="text-sm font-semibold text-foreground">
+                  {translate("useExternalAttachmentStorage")}
+                </span>
+                <span className="mt-2 text-xs leading-5 text-muted-foreground">
+                  {translate("useExternalAttachmentStorageDescription")}
+                </span>
+              </button>
+
+              <button
+                type="button"
+                onClick={chooseInternalStorage}
+                disabled={isChoosingStorage}
+                className="group flex min-h-40 flex-col items-start rounded-2xl border border-border bg-background/80 p-4 text-left shadow-sm transition-all hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+              >
+                <span className="mb-4 flex size-10 items-center justify-center rounded-xl bg-muted text-muted-foreground shadow-sm ring-1 ring-border">
+                  {isChoosingInternal ? <Loader2 className="size-4 animate-spin" /> : <HardDrive className="size-4" />}
+                </span>
+                <span className="text-sm font-semibold text-foreground">
+                  {translate("useBuiltInAttachmentStorage")}
+                </span>
+                <span className="mt-2 text-xs leading-5 text-muted-foreground">
+                  {translate("useBuiltInAttachmentStorageDescription")}
+                </span>
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {error && !isStorageDialogOpen && (
         <Alert variant="destructive" className="py-3">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
@@ -154,8 +315,18 @@ const PromptAttachmentEditor = ({
               className="flex items-center justify-between gap-3 rounded-2xl border border-border bg-muted/30 px-3 py-2.5"
             >
               <div className="flex min-w-0 items-center gap-3">
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-background text-muted-foreground ring-1 ring-border">
-                  <FileText className="size-4" />
+                <span className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-background text-muted-foreground ring-1 ring-border">
+                  {isImageAttachment(attachment) && attachment.thumbnailDataUrl ? (
+                    <img
+                      src={attachment.thumbnailDataUrl}
+                      alt={attachment.name}
+                      loading="lazy"
+                      decoding="async"
+                      className="size-9 object-cover"
+                    />
+                  ) : (
+                    <FileText className="size-4" />
+                  )}
                 </span>
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-foreground">{attachment.name}</p>

--- a/entrypoints/options/components/PromptAttachmentPreview.tsx
+++ b/entrypoints/options/components/PromptAttachmentPreview.tsx
@@ -362,39 +362,48 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
                 {t('loading')}
               </div>
             )}
-            <button
-              type="button"
-              onClick={() => setActiveImageId(null)}
-              className="absolute right-2 top-2 inline-flex size-10 items-center justify-center rounded-full bg-black/60 text-white transition-colors hover:bg-black/80 focus:outline-none focus:ring-2 focus:ring-white"
-              aria-label={t('closeImagePreview')}
-            >
-              <X className="size-5" />
-            </button>
-            {viewableImages.length > 1 && (
-              <>
-                <Button
-                  type="button"
-                  onClick={showPreviousImage}
-                  variant="ghost"
-                  size="icon"
-                  className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 text-white hover:bg-black/80 hover:text-white focus:ring-white"
-                  aria-label={t('previousImage')}
-                >
-                  <ChevronLeft className="size-6" />
-                </Button>
-                <Button
-                  type="button"
-                  onClick={showNextImage}
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/60 text-white hover:bg-black/80 hover:text-white focus:ring-white"
-                  aria-label={t('nextImage')}
-                >
-                  <ChevronRight className="size-6" />
-                </Button>
-              </>
-            )}
           </div>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation()
+              setActiveImageId(null)
+            }}
+            className="fixed right-4 top-4 z-[1001] inline-flex size-10 items-center justify-center rounded-full bg-black/60 text-white transition-colors hover:bg-black/80 focus:outline-none focus:ring-2 focus:ring-white"
+            aria-label={t('closeImagePreview')}
+          >
+            <X className="size-5" />
+          </button>
+          {viewableImages.length > 1 && (
+            <>
+              <Button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  showPreviousImage()
+                }}
+                variant="ghost"
+                size="icon"
+                className="fixed left-4 top-1/2 z-[1001] -translate-y-1/2 rounded-full bg-black/60 text-white hover:bg-black/80 hover:text-white focus:ring-white"
+                aria-label={t('previousImage')}
+              >
+                <ChevronLeft className="size-6" />
+              </Button>
+              <Button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  showNextImage()
+                }}
+                variant="ghost"
+                size="icon"
+                className="fixed right-4 top-1/2 z-[1001] -translate-y-1/2 rounded-full bg-black/60 text-white hover:bg-black/80 hover:text-white focus:ring-white"
+                aria-label={t('nextImage')}
+              >
+                <ChevronRight className="size-6" />
+              </Button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/entrypoints/options/components/PromptForm.tsx
+++ b/entrypoints/options/components/PromptForm.tsx
@@ -268,14 +268,14 @@ const PromptForm = ({
 
         <div>
           <label htmlFor='thumbnailUrl' className='mb-1.5 block text-sm font-medium text-foreground'>
-            {t('thumbnailUrlLabel')} <span className='font-normal text-muted-foreground'>({t('thumbnailUrlOptional')})</span>
+            {t('promptSourceUrlLabel')} <span className='font-normal text-muted-foreground'>({t('promptSourceUrlOptional')})</span>
           </label>
           <Input
             type='url'
             id='thumbnailUrl'
             value={thumbnailUrl}
             onChange={(e) => setThumbnailUrl(e.target.value)}
-            placeholder={t('thumbnailUrlPlaceholder')}
+            placeholder={t('promptSourceUrlPlaceholder')}
           />
           {thumbnailUrl && (
             <div className='mt-2'>

--- a/entrypoints/options/components/PromptForm.tsx
+++ b/entrypoints/options/components/PromptForm.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { AlertCircle, Info, Save, X } from "lucide-react"
 import type { PromptItem, Category, PromptAttachment } from '@/utils/types'
 import { getCategories } from '@/utils/categoryUtils'
 import { DEFAULT_CATEGORY_ID } from '@/utils/constants'
 import { getValidCategoryId } from '@/utils/promptUtils'
+import { fetchPromptSourcePreviewDataUrl } from '@/utils/promptSourcePreview'
 import PromptAttachmentEditor from './PromptAttachmentEditor'
 import PromptTagSelector from './PromptTagSelector'
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -43,7 +44,9 @@ const PromptForm = ({
   const [tags, setTags] = useState<string[]>([])
   const [notes, setNotes] = useState('')
   const [attachments, setAttachments] = useState<PromptAttachment[]>([])
-  const [thumbnailUrl, setThumbnailUrl] = useState('')
+  const [promptSourceUrl, setPromptSourceUrl] = useState('')
+  const [promptSourcePreviewDataUrl, setPromptSourcePreviewDataUrl] = useState('')
+  const [resolvedPromptSourceUrl, setResolvedPromptSourceUrl] = useState('')
   const [enabled, setEnabled] = useState(true)
   const [categoryId, setCategoryId] = useState(DEFAULT_CATEGORY_ID)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -51,7 +54,12 @@ const PromptForm = ({
   const [categories, setCategories] = useState<Category[]>([])
   const [loadingCategories, setLoadingCategories] = useState(true)
   const [newPromptId, setNewPromptId] = useState(() => crypto.randomUUID())
+  const promptSourceUrlRef = useRef('')
   const promptId = initialData?.id || newPromptId
+
+  useEffect(() => {
+    promptSourceUrlRef.current = promptSourceUrl
+  }, [promptSourceUrl])
 
   // 加载分类列表并初始化表单
   useEffect(() => {
@@ -68,7 +76,10 @@ const PromptForm = ({
           setTags(initialData.tags || [])
           setNotes(initialData.notes || '')
           setAttachments(initialData.attachments || [])
-          setThumbnailUrl(initialData.thumbnailUrl || '')
+          const sourceUrl = initialData.promptSourceUrl || (initialData as PromptItem & { thumbnailUrl?: string }).thumbnailUrl || ''
+          setPromptSourceUrl(sourceUrl)
+          setPromptSourcePreviewDataUrl(initialData.promptSourcePreviewDataUrl || '')
+          setResolvedPromptSourceUrl(initialData.promptSourcePreviewDataUrl ? sourceUrl : '')
           setEnabled(initialData.enabled !== undefined ? initialData.enabled : true)
           setCategoryId(getValidCategoryId(initialData.categoryId, enabledCategories))
         } else {
@@ -77,7 +88,9 @@ const PromptForm = ({
           setTags([])
           setNotes('')
           setAttachments([])
-          setThumbnailUrl('')
+          setPromptSourceUrl('')
+          setPromptSourcePreviewDataUrl('')
+          setResolvedPromptSourceUrl('')
           setEnabled(true)
           setCategoryId(getValidCategoryId(DEFAULT_CATEGORY_ID, enabledCategories))
         }
@@ -91,6 +104,38 @@ const PromptForm = ({
 
     initForm()
   }, [initialData, initialContent])
+
+  const handlePromptSourceUrlChange = (value: string) => {
+    setPromptSourceUrl(value)
+
+    if (value.trim() !== resolvedPromptSourceUrl) {
+      setPromptSourcePreviewDataUrl('')
+      setResolvedPromptSourceUrl('')
+    }
+  }
+
+  const resolvePromptSourcePreview = async (): Promise<string> => {
+    const sourceUrl = promptSourceUrl.trim()
+
+    if (!sourceUrl) {
+      setPromptSourcePreviewDataUrl('')
+      setResolvedPromptSourceUrl('')
+      return ''
+    }
+
+    if (sourceUrl === resolvedPromptSourceUrl && promptSourcePreviewDataUrl) {
+      return promptSourcePreviewDataUrl
+    }
+
+    const dataUrl = await fetchPromptSourcePreviewDataUrl(sourceUrl)
+
+    if (promptSourceUrlRef.current.trim() === sourceUrl) {
+      setPromptSourcePreviewDataUrl(dataUrl || '')
+      setResolvedPromptSourceUrl(dataUrl ? sourceUrl : '')
+    }
+
+    return dataUrl || ''
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -117,6 +162,10 @@ const PromptForm = ({
     try {
       const now = new Date().toISOString()
       const submittedPromptId = initialData?.id || newPromptId
+      const submittedPromptSourceUrl = promptSourceUrl.trim()
+      const submittedPromptSourcePreviewDataUrl = submittedPromptSourceUrl
+        ? await resolvePromptSourcePreview()
+        : ''
       // Create prompt object
       const promptData = {
         ...(submittedPromptId ? { id: submittedPromptId } : {}),
@@ -125,7 +174,8 @@ const PromptForm = ({
         tags,
         notes: notes.trim(),
         attachments,
-        thumbnailUrl: thumbnailUrl.trim() || undefined,
+        promptSourceUrl: submittedPromptSourceUrl || undefined,
+        promptSourcePreviewDataUrl: submittedPromptSourcePreviewDataUrl || undefined,
         enabled,
         categoryId,
         createdAt: initialData?.createdAt || now,
@@ -141,7 +191,9 @@ const PromptForm = ({
         setTags([])
         setNotes('')
         setAttachments([])
-        setThumbnailUrl('')
+        setPromptSourceUrl('')
+        setPromptSourcePreviewDataUrl('')
+        setResolvedPromptSourceUrl('')
         setNewPromptId(crypto.randomUUID())
         // 保持当前分类选中，而不是重置为可能无效的默认分类
       }
@@ -267,25 +319,23 @@ const PromptForm = ({
         />
 
         <div>
-          <label htmlFor='thumbnailUrl' className='mb-1.5 block text-sm font-medium text-foreground'>
+          <label htmlFor='promptSourceUrl' className='mb-1.5 block text-sm font-medium text-foreground'>
             {t('promptSourceUrlLabel')} <span className='font-normal text-muted-foreground'>({t('promptSourceUrlOptional')})</span>
           </label>
           <Input
             type='url'
-            id='thumbnailUrl'
-            value={thumbnailUrl}
-            onChange={(e) => setThumbnailUrl(e.target.value)}
+            id='promptSourceUrl'
+            value={promptSourceUrl}
+            onChange={(e) => handlePromptSourceUrlChange(e.target.value)}
+            onBlur={() => void resolvePromptSourcePreview()}
             placeholder={t('promptSourceUrlPlaceholder')}
           />
-          {thumbnailUrl && (
+          {promptSourcePreviewDataUrl && (
             <div className='mt-2'>
               <img
-                src={thumbnailUrl}
-                alt='Thumbnail preview'
+                src={promptSourcePreviewDataUrl}
+                alt={t('promptSourceUrlPreviewAlt')}
                 className='max-h-32 max-w-32 rounded-xl border border-border object-cover'
-                onError={(e) => {
-                  (e.target as HTMLImageElement).style.display = 'none'
-                }}
                 onLoad={(e) => {
                   (e.target as HTMLImageElement).style.display = 'block'
                 }}

--- a/entrypoints/options/components/PromptManager.tsx
+++ b/entrypoints/options/components/PromptManager.tsx
@@ -22,7 +22,7 @@ import ConfirmModal from "./ConfirmModal";
 import "../App.css";
 import "~/assets/tailwind.css";
 import { PromptItem, Category } from "@/utils/types";
-import { getCategories, migratePromptsWithCategory } from "@/utils/categoryUtils";
+import { getCategories, migratePromptsWithCategory, saveCategories } from "@/utils/categoryUtils";
 import { getAllPrompts, setAllPrompts } from "@/utils/promptStore";
 import {
   type AttachmentStorageRootHandle,
@@ -36,12 +36,18 @@ import {
 import {
   sortPrompts,
   filterPrompts,
-  validateAndNormalizePrompts,
   mergePrompts,
   PromptValidationException,
   PROMPT_VALIDATION_ERRORS,
   SortType,
 } from "@/utils/promptUtils";
+import {
+  createPromptBackupZip,
+  mergePromptBackupCategories,
+  parsePromptBackupBlob,
+  restorePromptBackupAttachments,
+  type PromptBackupAttachmentFile,
+} from "@/utils/promptBackupArchive";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -69,6 +75,25 @@ const getAuthorizedAttachmentRoot = async (): Promise<AttachmentStorageRootHandl
   }
 
   return root;
+};
+
+const hasPromptAttachments = (prompts: PromptItem[]): boolean => (
+  prompts.some((prompt) => Array.isArray(prompt.attachments) && prompt.attachments.length > 0)
+);
+
+const padDatePart = (value: number): string => value.toString().padStart(2, "0");
+
+export const formatPromptBackupFileName = (date: Date = new Date()): string => {
+  const timestamp = [
+    date.getFullYear().toString(),
+    padDatePart(date.getMonth() + 1),
+    padDatePart(date.getDate()),
+    padDatePart(date.getHours()),
+    padDatePart(date.getMinutes()),
+    padDatePart(date.getSeconds()),
+  ].join("");
+
+  return `quick-prompt-backup-${timestamp}.zip`;
 };
 
 export const deletePromptWithAttachments = async (
@@ -269,13 +294,22 @@ const PromptManager = () => {
     }
   };
 
+  const savePromptCategories = async (newCategories: Category[]) => {
+    await saveCategories(newCategories);
+    setCategories(newCategories);
+  };
+
   // 处理导入结果
   const handleImportResult = async (
     validPrompts: PromptItem[],
     confirmMessageKey: string,
-    onSuccess?: () => void
+    onSuccess?: () => void,
+    importedCategories: Category[] = [],
+    attachmentFiles: PromptBackupAttachmentFile[] = []
   ): Promise<boolean> => {
-    if (prompts.length > 0) {
+    const shouldConfirmImport = prompts.length > 0 || (categories.length > 0 && importedCategories.length > 0);
+
+    if (shouldConfirmImport) {
       const shouldImport = window.confirm(
         t(confirmMessageKey, [prompts.length.toString(), validPrompts.length.toString()])
       );
@@ -286,18 +320,37 @@ const PromptManager = () => {
       }
 
       const { merged, addedCount, updatedCount } = mergePrompts(prompts, validPrompts);
+      const categoryMerge = mergePromptBackupCategories(categories, importedCategories);
+      const categoryChangeCount = categoryMerge.addedCount + categoryMerge.updatedCount;
+      const changedCount = addedCount + updatedCount + categoryChangeCount;
 
-      if (addedCount === 0 && updatedCount === 0) {
+      if (changedCount === 0) {
         alert(t('noNewPromptsFound'));
         onSuccess?.();
         return false;
       }
 
+      if (attachmentFiles.length > 0) {
+        const root = await getAuthorizedAttachmentRoot();
+        await restorePromptBackupAttachments(root, attachmentFiles);
+      }
+
       await savePrompts(merged);
-      alert(t('importSuccessful', [(addedCount + updatedCount).toString()]));
+      if (categoryChangeCount > 0) {
+        await savePromptCategories(categoryMerge.categories);
+      }
+      alert(t('importSuccessful', [changedCount.toString()]));
     } else {
+      if (attachmentFiles.length > 0) {
+        const root = await getAuthorizedAttachmentRoot();
+        await restorePromptBackupAttachments(root, attachmentFiles);
+      }
+
       await savePrompts(validPrompts);
-      alert(t('importSuccessful', [validPrompts.length.toString()]));
+      if (importedCategories.length > 0) {
+        await savePromptCategories(importedCategories);
+      }
+      alert(t('importSuccessful', [(validPrompts.length + importedCategories.length).toString()]));
     }
 
     onSuccess?.();
@@ -476,19 +529,19 @@ const PromptManager = () => {
   };
 
   // 导出提示词
-  const exportPrompts = () => {
+  const exportPrompts = async () => {
     if (prompts.length === 0) {
       alert(t('noPromptsToExport'));
       return;
     }
 
     try {
-      const dataStr = JSON.stringify(prompts, null, 2);
-      const dataBlob = new Blob([dataStr], { type: "application/json" });
+      const root = hasPromptAttachments(prompts) ? await getAuthorizedAttachmentRoot() : undefined;
+      const dataBlob = await createPromptBackupZip(root, prompts, categories);
       const url = URL.createObjectURL(dataBlob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = `prompts-export-${new Date().toISOString().slice(0, 10)}.json`;
+      link.download = formatPromptBackupFileName();
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -534,11 +587,15 @@ const PromptManager = () => {
     };
 
     try {
-      const fileContent = await file.text();
-      const importedData = JSON.parse(fileContent);
-      const validPrompts = validateAndNormalizePrompts(importedData);
+      const importedData = await parsePromptBackupBlob(file);
 
-      await handleImportResult(validPrompts, 'importPromptsConfirm');
+      await handleImportResult(
+        importedData.prompts,
+        'importPromptsConfirm',
+        undefined,
+        importedData.categories,
+        importedData.attachmentFiles
+      );
       clearFileInput();
     } catch (err) {
       console.error(t('importPromptsError'), err);
@@ -588,11 +645,15 @@ const PromptManager = () => {
         );
       }
 
-      const fileContent = await response.text();
-      const importedData = JSON.parse(fileContent);
-      const validPrompts = validateAndNormalizePrompts(importedData);
+      const importedData = await parsePromptBackupBlob(await response.blob());
 
-      await handleImportResult(validPrompts, 'remoteImportPromptsConfirm', closeRemoteImportModal);
+      await handleImportResult(
+        importedData.prompts,
+        'remoteImportPromptsConfirm',
+        closeRemoteImportModal,
+        importedData.categories,
+        importedData.attachmentFiles
+      );
     } catch (err) {
       console.error(t('remoteImportPromptsError'), err);
       setError(t('remoteImportFailed', [getValidationErrorMessage(err)]));
@@ -671,7 +732,7 @@ const PromptManager = () => {
                 type="file"
                 ref={fileInputRef}
                 onChange={importPrompts}
-                accept=".json"
+                accept=".json,.zip"
                 className="hidden"
               />
             </>
@@ -834,7 +895,7 @@ const PromptManager = () => {
                     id="remote-url"
                     value={remoteUrl}
                     onChange={handleRemoteUrlChange}
-                    placeholder="https://example.com/prompts.json"
+                    placeholder="https://example.com/quick-prompt-backup.zip"
                     className="pl-9"
                   />
                 </div>

--- a/entrypoints/options/components/Sidebar.tsx
+++ b/entrypoints/options/components/Sidebar.tsx
@@ -182,7 +182,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className = "" }) => {
               )}
               title="Quick Prompt"
             >
-              <img src={Logo} alt="Quick Prompt Logo" className="size-9 rounded-2xl shadow-sm" />
+              <img src={Logo} alt="Quick Prompt Logo" className="size-9" />
               {!collapsed && (
                 <div className="min-w-0">
                   <div className="truncate text-sm font-semibold">Quick Prompt</div>

--- a/entrypoints/options/components/SortablePromptCard.tsx
+++ b/entrypoints/options/components/SortablePromptCard.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   Clock3,
   Copy,
+  ExternalLink,
   FileText,
   GripVertical,
   Pencil,
@@ -104,6 +105,8 @@ const SortablePromptCard: React.FC<SortablePromptCardProps> = ({
     WebkitBoxOrient: "vertical",
     WebkitLineClamp: compactTextLineCount,
   } as React.CSSProperties;
+  const promptSourceUrl = prompt.promptSourceUrl?.trim();
+  const promptSourcePreviewDataUrl = prompt.promptSourcePreviewDataUrl?.trim();
 
   const formatTime = (timestamp?: string) => {
     if (!timestamp) return t("noModificationTime");
@@ -217,6 +220,41 @@ const SortablePromptCard: React.FC<SortablePromptCardProps> = ({
     </div>
   );
 
+  const PromptSourceLink = ({ compact: compactLink = false }: { compact?: boolean }) => (
+    promptSourceUrl ? (
+      <a
+        href={promptSourceUrl}
+        target="_blank"
+        rel="noreferrer"
+        title={promptSourceUrl}
+        aria-label={t("promptSourceUrlLabel")}
+        onClick={(event) => event.stopPropagation()}
+        className={cn(
+          "inline-flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+          compactLink ? "rounded-lg p-1" : "min-w-0",
+        )}
+      >
+        <ExternalLink className={compactLink ? "size-3.5" : "size-3.5 shrink-0"} />
+        {!compactLink && (
+          <span className="max-w-[14rem] truncate">{t("promptSourceUrlLabel")}</span>
+        )}
+      </a>
+    ) : null
+  );
+
+  const renderPromptSourceImagePreview = () => (
+    promptSourcePreviewDataUrl ? (
+      <img
+        src={promptSourcePreviewDataUrl}
+        alt={t("promptSourceUrlPreviewAlt")}
+        className="size-24 shrink-0 rounded-2xl border border-border object-cover"
+        onLoad={(e) => {
+          (e.target as HTMLImageElement).style.display = "block";
+        }}
+      />
+    ) : null
+  );
+
   if (compact) {
     return (
       <Card
@@ -303,6 +341,7 @@ const SortablePromptCard: React.FC<SortablePromptCardProps> = ({
               {category.name}
             </Badge>
           )}
+          <PromptSourceLink compact />
           <div className="qp-compact-actions flex shrink-0 items-center gap-1">
             <ActionButtons small />
           </div>
@@ -427,19 +466,10 @@ const SortablePromptCard: React.FC<SortablePromptCardProps> = ({
               <FileText className="size-3.5" />
               {t("promptCharacterCount")}: {t("promptCharacterCountValue", [characterCount.toString()])}
             </div>
+            <PromptSourceLink />
           </div>
         </div>
-
-        {prompt.thumbnailUrl && (
-          <img
-            src={prompt.thumbnailUrl}
-            alt={prompt.title}
-            className="size-24 shrink-0 rounded-2xl border border-border object-cover"
-            onError={(e) => {
-              (e.target as HTMLImageElement).style.display = "none";
-            }}
-          />
-        )}
+        {renderPromptSourceImagePreview()}
       </div>
 
       <div className="flex justify-end border-t border-border bg-muted/35 px-4 py-3">

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -215,7 +215,7 @@ function App() {
       className="w-[360px] min-w-[320px] max-w-[420px] bg-background p-4 text-foreground"
     >
       <div className="mb-4 flex items-center gap-3">
-        <img src={Logo} className="size-10 rounded-2xl shadow-sm" alt="quick prompt logo" />
+        <img src={Logo} className="size-10" alt="quick prompt logo" />
         <div className="min-w-0">
           <h1 className="text-base font-semibold leading-tight">Quick Prompt</h1>
           <p className="text-xs text-muted-foreground">{t("usage")}</p>

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1583,7 +1583,7 @@
     "message": "Attachment Storage"
   },
   "attachmentStorageDescription": {
-    "message": "Choose how to store attachments before opening the management page. An external local folder is extremely recommended for better performance and larger storage capacity."
+    "message": "Choose how to store attachments before your first upload. An external local folder is strongly recommended for better performance and larger storage capacity."
   },
   "attachmentStorageRecommended": {
     "message": "Recommended"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -410,7 +410,7 @@
     "message": "No valid prompts found in the file"
   },
   "importPromptsConfirm": {
-    "message": "You already have $existingCount$ prompts, found $newCount$ prompts to import.\nClick \"OK\" to import new prompts, or \"Cancel\" to abort.",
+    "message": "You already have $existingCount$ prompts and found $newCount$ prompts to import. Categories and attachments in the backup will be imported too.\nClick \"OK\" to import data, or \"Cancel\" to abort.",
     "placeholders": {
       "existingCount": {
         "content": "$1"
@@ -421,7 +421,7 @@
     }
   },
   "noNewPromptsFound": {
-    "message": "No new prompts found, import cancelled."
+    "message": "No new prompts or categories found, import cancelled."
   },
   "importPromptsFailed": {
     "message": "Failed to import prompts: $error$",
@@ -441,7 +441,7 @@
     "message": "No valid prompts found in remote data"
   },
   "remoteImportPromptsConfirm": {
-    "message": "You already have $existingCount$ prompts, found $newCount$ prompts from remote source.\nClick \"OK\" to import new prompts, or \"Cancel\" to abort.",
+    "message": "You already have $existingCount$ prompts and found $newCount$ prompts from the remote source. Categories and attachments in the backup will be imported too.\nClick \"OK\" to import data, or \"Cancel\" to abort.",
     "placeholders": {
       "existingCount": {
         "content": "$1"
@@ -466,7 +466,7 @@
     "message": "No prompts to export"
   },
   "exportAllPrompts": {
-    "message": "Export all prompts"
+    "message": "Export all prompt data, including categories and attachments"
   },
   "importFromUrl": {
     "message": "Import prompts from URL"
@@ -565,7 +565,7 @@
     "message": "Import instructions"
   },
   "importInstructionsDetail": {
-    "message": "Enter the URL link containing valid prompt JSON data, and the system will automatically fetch and import the data."
+    "message": "Enter a URL containing a Quick Prompt backup ZIP or prompt JSON data. The system will fetch and import it automatically."
   },
   "remoteUrl": {
     "message": "Remote URL"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1384,6 +1384,9 @@
   "promptSourceUrlPlaceholder": {
     "message": "https://placehold.co/80x80/6366f1/white?text=local"
   },
+  "promptSourceUrlPreviewAlt": {
+    "message": "Prompt source URL preview"
+  },
   "duplicate": {
     "message": "Duplicate"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -547,8 +547,8 @@
   "addNewPrompt": {
     "message": "Add new prompt"
   },
-  "viewAllCategories": {
-    "message": "View all categories"
+  "viewAllPrompts": {
+    "message": "View prompts"
   },
   "createFirstPrompt": {
     "message": "Create your first prompt to boost productivity"
@@ -1375,14 +1375,14 @@
   "unpinPrompt": {
     "message": "Unpin prompt"
   },
-  "thumbnailUrlLabel": {
-    "message": "Thumbnail URL"
+  "promptSourceUrlLabel": {
+    "message": "Prompt source URL"
   },
-  "thumbnailUrlOptional": {
+  "promptSourceUrlOptional": {
     "message": "optional"
   },
-  "thumbnailUrlPlaceholder": {
-    "message": "https://example.com/image.png"
+  "promptSourceUrlPlaceholder": {
+    "message": "https://placehold.co/80x80/6366f1/white?text=local"
   },
   "duplicate": {
     "message": "Duplicate"

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -413,7 +413,7 @@
     "message": "导入的文件中没有有效的提示词"
   },
   "importPromptsConfirm": {
-    "message": "您已有$existingCount$个提示词，发现$newCount$个待导入提示词。\n点击\"确定\"导入新提示词，点击\"取消\"不进行任何操作。",
+    "message": "您已有$existingCount$个提示词，发现$newCount$个待导入提示词。若备份中包含分类和附件，也会一并导入。\n点击\"确定\"导入数据，点击\"取消\"不进行任何操作。",
     "placeholders": {
       "existingCount": {
         "content": "$1"
@@ -424,7 +424,7 @@
     }
   },
   "noNewPromptsFound": {
-    "message": "没有发现新的提示词，导入已取消。"
+    "message": "没有发现新的提示词或分类，导入已取消。"
   },
   "importPromptsFailed": {
     "message": "导入 Prompts 失败: $error$",
@@ -444,7 +444,7 @@
     "message": "远程数据中没有有效的提示词"
   },
   "remoteImportPromptsConfirm": {
-    "message": "您已有$existingCount$个提示词，从远程发现$newCount$个待导入提示词。\n点击\"确定\"导入新提示词，点击\"取消\"不进行任何操作。",
+    "message": "您已有$existingCount$个提示词，从远程发现$newCount$个待导入提示词。若备份中包含分类和附件，也会一并导入。\n点击\"确定\"导入数据，点击\"取消\"不进行任何操作。",
     "placeholders": {
       "existingCount": {
         "content": "$1"
@@ -469,7 +469,7 @@
     "message": "没有提示词可导出"
   },
   "exportAllPrompts": {
-    "message": "导出所有提示词"
+    "message": "导出所有提示词数据（含分类和附件）"
   },
   "importFromUrl": {
     "message": "从URL导入提示词"
@@ -568,7 +568,7 @@
     "message": "导入说明"
   },
   "importInstructionsDetail": {
-    "message": "输入包含有效提示词 JSON 数据的 URL 链接，系统将自动获取并导入数据。"
+    "message": "输入包含 Quick Prompt 备份 ZIP 或提示词 JSON 数据的 URL 链接，系统将自动获取并导入数据。"
   },
   "remoteUrl": {
     "message": "远程 URL"

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -550,8 +550,8 @@
   "addNewPrompt": {
     "message": "新增提示词"
   },
-  "viewAllCategories": {
-    "message": "查看所有分类"
+  "viewAllPrompts": {
+    "message": "查看提示词"
   },
   "createFirstPrompt": {
     "message": "创建您的第一个提示词，开始提升工作效率"
@@ -1375,14 +1375,14 @@
   "unpinPrompt": {
     "message": "取消置顶提示词"
   },
-  "thumbnailUrlLabel": {
-    "message": "缩略图 URL"
+  "promptSourceUrlLabel": {
+    "message": "提示词来源URL"
   },
-  "thumbnailUrlOptional": {
+  "promptSourceUrlOptional": {
     "message": "可选"
   },
-  "thumbnailUrlPlaceholder": {
-    "message": "https://example.com/image.png"
+  "promptSourceUrlPlaceholder": {
+    "message": "https://placehold.co/80x80/6366f1/white?text=local"
   },
   "duplicate": {
     "message": "创建副本"

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -1583,7 +1583,7 @@
     "message": "附件存储"
   },
   "attachmentStorageDescription": {
-    "message": "首次进入管理页前，请选择附件存储方式。强烈推荐使用外部自定义文件夹，能更好地管理和备份附件文件。"
+    "message": "首次上传附件前，请选择附件存储方式。强烈推荐使用外部自定义文件夹，能更好地管理和备份附件文件。"
   },
   "attachmentStorageRecommended": {
     "message": "推荐"

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -1384,6 +1384,9 @@
   "promptSourceUrlPlaceholder": {
     "message": "https://placehold.co/80x80/6366f1/white?text=local"
   },
+  "promptSourceUrlPreviewAlt": {
+    "message": "提示词来源URL预览"
+  },
   "duplicate": {
     "message": "创建副本"
   },

--- a/tests/content/PromptAttachmentPreview.test.tsx
+++ b/tests/content/PromptAttachmentPreview.test.tsx
@@ -213,11 +213,20 @@ describe('content PromptAttachmentPreview', () => {
     const dialog = screen.getByRole('dialog', { name: 'localized:imagePreviewDialog' })
     expect(dialog).toBeInTheDocument()
     expect(within(dialog).getByRole('img', { name: 'first.png' })).toHaveAttribute('src', 'blob:first-content-preview')
+    const imageStage = within(dialog).getByRole('img', { name: 'first.png' }).closest('.qp-image-viewer-inner')
 
     fireEvent.click(screen.getByRole('button', { name: 'localized:nextImage' }))
     expect(within(dialog).getByRole('img', { name: 'second.png' })).toHaveAttribute('src', 'blob:second-content-preview')
-    expect(screen.getByRole('button', { name: 'localized:closeImagePreview' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'localized:previousImage' })).toBeInTheDocument()
+    const closeButton = screen.getByRole('button', { name: 'localized:closeImagePreview' })
+    const previousButton = screen.getByRole('button', { name: 'localized:previousImage' })
+    const nextButton = screen.getByRole('button', { name: 'localized:nextImage' })
+
+    expect(closeButton.parentElement).toBe(dialog)
+    expect(previousButton.parentElement).toBe(dialog)
+    expect(nextButton.parentElement).toBe(dialog)
+    expect(imageStage).not.toContainElement(closeButton)
+    expect(imageStage).not.toContainElement(previousButton)
+    expect(imageStage).not.toContainElement(nextButton)
   })
 
   it('loads immediately when IntersectionObserver is unavailable and revokes object URLs on unmount', async () => {

--- a/tests/content/PromptAttachmentPreview.test.tsx
+++ b/tests/content/PromptAttachmentPreview.test.tsx
@@ -120,6 +120,46 @@ describe('content PromptAttachmentPreview', () => {
     await waitFor(() => expect(sendMessage).not.toHaveBeenCalled())
   })
 
+  it('opens the image viewer without bubbling the click to the prompt item', async () => {
+    sendMessage.mockResolvedValue({ success: false })
+    const parentClick = vi.fn()
+
+    render(
+      <div onClick={parentClick}>
+        <PromptAttachmentPreview
+          attachments={[createAttachment({ thumbnailDataUrl: 'data:image/webp;base64,thumbnail' })]}
+        />
+      </div>
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'image.png' }))
+    })
+
+    expect(parentClick).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog', { name: 'localized:imagePreviewDialog' })).toBeInTheDocument()
+  })
+
+  it('renders the image viewer as a separate preview layer outside the attachment list', async () => {
+    sendMessage.mockResolvedValue({ success: false })
+
+    const { container } = render(
+      <PromptAttachmentPreview
+        attachments={[createAttachment({ thumbnailDataUrl: 'data:image/webp;base64,thumbnail' })]}
+      />
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'image.png' }))
+    })
+
+    const attachmentList = container.querySelector('.qp-attachments')
+    const viewer = screen.getByRole('dialog', { name: 'localized:imagePreviewDialog' })
+
+    expect(viewer).toHaveClass('qp-image-viewer')
+    expect(attachmentList).not.toContainElement(viewer)
+  })
+
   it('prefers a newly stored thumbnail over a previously loaded content preview', async () => {
     vi.mocked(URL.createObjectURL).mockReturnValue('blob:stale-content-preview')
     sendMessage.mockResolvedValue({

--- a/tests/content/PromptAttachmentPreview.test.tsx
+++ b/tests/content/PromptAttachmentPreview.test.tsx
@@ -67,7 +67,7 @@ describe('content PromptAttachmentPreview', () => {
     await waitFor(() => expect(sendMessage).not.toHaveBeenCalled())
   })
 
-  it('keeps metadata visible and lazy-loads image previews when intersecting', async () => {
+  it('shows only the image thumbnail without filename, size, or an outer tile border', async () => {
     sendMessage.mockResolvedValue({
       success: true,
       base64: btoa('image-bytes'),
@@ -76,8 +76,8 @@ describe('content PromptAttachmentPreview', () => {
 
     render(<PromptAttachmentPreview attachments={[createAttachment()]} />)
 
-    expect(screen.getByText('image.png')).toBeInTheDocument()
-    expect(screen.getByText('1.5 KB')).toBeInTheDocument()
+    expect(screen.queryByText('image.png')).not.toBeInTheDocument()
+    expect(screen.queryByText('1.5 KB')).not.toBeInTheDocument()
     expect(sendMessage).not.toHaveBeenCalled()
 
     act(() => {
@@ -85,8 +85,11 @@ describe('content PromptAttachmentPreview', () => {
     })
 
     const image = await screen.findByRole('img', { name: 'image.png' })
+    const attachmentTile = image.closest('.qp-attachment')
+
     expect(image).toHaveAttribute('src', 'blob:content-preview-url')
     expect(image).toHaveClass('qp-attachment-image')
+    expect(attachmentTile).toHaveClass('qp-attachment-image-only')
     expect(sendMessage).toHaveBeenCalledWith({
       action: 'getAttachmentPreview',
       attachment: createAttachment(),
@@ -105,6 +108,8 @@ describe('content PromptAttachmentPreview', () => {
     expect(image).toHaveAttribute('src', 'data:image/webp;base64,thumbnail')
     expect(image).toHaveAttribute('loading', 'lazy')
     expect(image).toHaveAttribute('decoding', 'async')
+    expect(screen.queryByText('image.png')).not.toBeInTheDocument()
+    expect(screen.queryByText('1.5 KB')).not.toBeInTheDocument()
 
     if (MockIntersectionObserver.instances[0]) {
       act(() => {
@@ -189,5 +194,16 @@ describe('content PromptAttachmentPreview', () => {
     unmount()
 
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:content-preview-url')
+  })
+
+  it('keeps metadata visible for non-image attachments', () => {
+    render(
+      <PromptAttachmentPreview
+        attachments={[createAttachment({ name: 'notes.pdf', type: 'application/pdf', size: 2048 })]}
+      />
+    )
+
+    expect(screen.getByText('notes.pdf')).toBeInTheDocument()
+    expect(screen.getByText('2 KB')).toBeInTheDocument()
   })
 })

--- a/tests/content/PromptSelector.test.tsx
+++ b/tests/content/PromptSelector.test.tsx
@@ -172,11 +172,31 @@ describe('content PromptSelector', () => {
     })
   })
 
+  it('keeps clicking the prompt item outside attachments applying the prompt', async () => {
+    const target = createTarget()
+
+    await act(async () => {
+      showPromptSelector([createPrompt()], target)
+    })
+
+    const host = document.getElementById('quick-prompt-selector')!
+    const shadowRoot = host.shadowRoot!
+
+    await waitFor(() => {
+      expect(shadowRoot.querySelector('.qp-prompt-item')).not.toBeNull()
+    })
+
+    fireEvent.click(shadowRoot.querySelector('.qp-prompt-preview')!)
+
+    expect(target.value).toBe('Prompt content')
+  })
+
   it('sets pointer cursors for shadow-dom clickable controls on hover', () => {
     const styles = getPromptSelectorStyles()
 
     expect(styles).toContain('button:not(:disabled):hover')
     expect(styles).toContain('[role="button"]:not([aria-disabled="true"]):hover')
     expect(styles).toContain('a[href]:hover')
+    expect(styles).toMatch(/\.qp-attachment-image\s*\{[\s\S]*cursor:\s*zoom-in\s*!important;/)
   })
 })

--- a/tests/content/PromptSelector.test.tsx
+++ b/tests/content/PromptSelector.test.tsx
@@ -172,6 +172,27 @@ describe('content PromptSelector', () => {
     })
   })
 
+  it('renders prompt source URL image previews in the selector', async () => {
+    await act(async () => {
+      showPromptSelector([
+        createPrompt({
+          promptSourceUrl: 'https://cdn.example.cn/source.png',
+          promptSourcePreviewDataUrl: 'data:image/png;base64,saved-preview',
+        }),
+      ], createTarget())
+    })
+
+    const host = document.getElementById('quick-prompt-selector')!
+    const shadowRoot = host.shadowRoot!
+
+    await waitFor(() => {
+      const preview = shadowRoot.querySelector('.qp-prompt-source-preview-img') as HTMLImageElement | null
+      expect(preview).not.toBeNull()
+      expect(preview).toHaveAttribute('src', 'data:image/png;base64,saved-preview')
+      expect(preview).toHaveAttribute('alt', 'translated:promptSourceUrlPreviewAlt')
+    })
+  })
+
   it('keeps clicking the prompt item outside attachments applying the prompt', async () => {
     const target = createTarget()
 
@@ -198,5 +219,6 @@ describe('content PromptSelector', () => {
     expect(styles).toContain('[role="button"]:not([aria-disabled="true"]):hover')
     expect(styles).toContain('a[href]:hover')
     expect(styles).toMatch(/\.qp-attachment-image\s*\{[\s\S]*cursor:\s*zoom-in\s*!important;/)
+    expect(styles).toMatch(/\.qp-image-viewer-close,\s*\.qp-image-viewer-nav\s*\{[\s\S]*position:\s*fixed\s*!important;/)
   })
 })

--- a/tests/options/AppBrandingAndAttachmentGate.test.ts
+++ b/tests/options/AppBrandingAndAttachmentGate.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("options shell branding and attachment gate", () => {
+  it("does not block the options app behind the attachment storage gate", () => {
+    const source = readFileSync("entrypoints/options/App.tsx", "utf8");
+
+    expect(source).not.toContain("AttachmentStorageGate");
+  });
+
+  it("renders the sidebar logo without rounded or shadow framing", () => {
+    const source = readFileSync("entrypoints/options/components/Sidebar.tsx", "utf8");
+
+    expect(source).toContain('alt="Quick Prompt Logo"');
+    expect(source).not.toContain('className="size-9 rounded-2xl shadow-sm"');
+  });
+
+  it("renders the popup logo without rounded or shadow framing", () => {
+    const source = readFileSync("entrypoints/popup/App.tsx", "utf8");
+
+    expect(source).toContain('alt="quick prompt logo"');
+    expect(source).not.toContain('className="size-10 rounded-2xl shadow-sm"');
+  });
+});

--- a/tests/options/CategoryList.test.tsx
+++ b/tests/options/CategoryList.test.tsx
@@ -68,4 +68,21 @@ describe('CategoryList', () => {
     expect(onToggleEnabled).toHaveBeenCalledWith('work', false)
     expect(onSelect).not.toHaveBeenCalled()
   })
+
+  it('uses the prompt-focused view action label', () => {
+    render(
+      <CategoryList
+        categories={[createCategory()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSelect={vi.fn()}
+        searchTerm=""
+        allCategoriesCount={1}
+        promptCounts={{ work: 3 }}
+      />
+    )
+
+    expect(screen.getByText('viewAllPrompts')).toBeInTheDocument()
+    expect(screen.queryByText('viewAllCategories')).not.toBeInTheDocument()
+  })
 })

--- a/tests/options/PromptAttachmentEditor.test.tsx
+++ b/tests/options/PromptAttachmentEditor.test.tsx
@@ -4,7 +4,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { PromptAttachment } from '@/utils/types'
 
 vi.mock('@/utils/attachments/fileSystem', () => ({
+  getAttachmentStorageMode: vi.fn().mockResolvedValue('external'),
   getAttachmentRootHandle: vi.fn().mockResolvedValue({ name: 'root' }),
+  pickAndStoreAttachmentRoot: vi.fn().mockResolvedValue({ name: 'root' }),
+  useInternalAttachmentStorage: vi.fn().mockResolvedValue({ name: 'internal-root' }),
   verifyReadWritePermission: vi.fn().mockResolvedValue(true),
   removeAttachmentDirectoryFromRoot: vi.fn(),
   removeAttachmentFileFromRoot: vi.fn(),
@@ -46,6 +49,15 @@ const createAttachment = (overrides: Partial<PromptAttachment> = {}): PromptAtta
 describe('PromptAttachmentEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(fileSystem.getAttachmentStorageMode).mockResolvedValue('external')
+    vi.mocked(fileSystem.getAttachmentRootHandle).mockResolvedValue({ name: 'root' } as any)
+    vi.mocked(fileSystem.pickAndStoreAttachmentRoot).mockResolvedValue({ name: 'root' } as any)
+    vi.mocked(fileSystem.useInternalAttachmentStorage).mockResolvedValue({ name: 'internal-root' } as any)
+    vi.mocked(fileSystem.verifyReadWritePermission).mockResolvedValue(true)
+    Object.defineProperty(window, 'showDirectoryPicker', {
+      value: vi.fn(),
+      configurable: true,
+    })
   })
 
   it('adds selected files and reports the updated attachment list', async () => {
@@ -60,6 +72,60 @@ describe('PromptAttachmentEditor', () => {
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ name: 'hello.txt' })])
     })
+  })
+
+  it('prompts for an attachment storage choice when upload is clicked without a configured root', async () => {
+    vi.mocked(fileSystem.getAttachmentStorageMode).mockResolvedValue(undefined)
+    vi.mocked(fileSystem.getAttachmentRootHandle).mockResolvedValue(undefined)
+    const onChange = vi.fn()
+
+    render(<PromptAttachmentEditor promptId="prompt-1" attachments={[]} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'addAttachment' }))
+
+    expect(await screen.findByRole('dialog', { name: 'attachmentStorageTitle' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /useExternalAttachmentStorage/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /useBuiltInAttachmentStorage/ })).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('opens the file picker after choosing built-in storage from the upload prompt', async () => {
+    vi.mocked(fileSystem.getAttachmentStorageMode).mockResolvedValue(undefined)
+    vi.mocked(fileSystem.getAttachmentRootHandle).mockResolvedValue(undefined)
+    const inputClick = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+
+    render(<PromptAttachmentEditor promptId="prompt-1" attachments={[]} onChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'addAttachment' }))
+    fireEvent.click(await screen.findByRole('button', { name: /useBuiltInAttachmentStorage/ }))
+
+    await waitFor(() => {
+      expect(fileSystem.useInternalAttachmentStorage).toHaveBeenCalled()
+      expect(inputClick).toHaveBeenCalled()
+    })
+    expect(screen.queryByRole('dialog', { name: 'attachmentStorageTitle' })).not.toBeInTheDocument()
+
+    inputClick.mockRestore()
+  })
+
+  it('shows image attachment thumbnails in the editor list', () => {
+    render(
+      <PromptAttachmentEditor
+        promptId="prompt-1"
+        attachments={[
+          createAttachment({
+            name: 'photo.png',
+            type: 'image/png',
+            thumbnailDataUrl: 'data:image/webp;base64,thumbnail',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    const image = screen.getByRole('img', { name: 'photo.png' })
+    expect(image).toHaveAttribute('src', 'data:image/webp;base64,thumbnail')
+    expect(image).toHaveClass('object-cover')
   })
 
   it('removes an attachment and reports the updated list', async () => {

--- a/tests/options/PromptAttachmentPreview.test.tsx
+++ b/tests/options/PromptAttachmentPreview.test.tsx
@@ -192,12 +192,20 @@ describe('PromptAttachmentPreview', () => {
     const dialog = await screen.findByRole('dialog', { name: 'imagePreviewDialog' })
     expect(dialog).toBeInTheDocument()
     expect(within(dialog).getByRole('img', { name: 'first.png' })).toHaveAttribute('src', 'blob:first-preview')
+    const imageStage = within(dialog).getByRole('img', { name: 'first.png' }).parentElement
 
     fireEvent.click(screen.getByRole('button', { name: 'nextImage' }))
     expect(within(dialog).getByRole('img', { name: 'second.png' })).toHaveAttribute('src', 'blob:second-preview')
+    expect(screen.getByRole('button', { name: 'nextImage' }).parentElement).toBe(dialog)
 
     fireEvent.click(screen.getByRole('button', { name: 'previousImage' }))
     expect(within(dialog).getByRole('img', { name: 'first.png' })).toHaveAttribute('src', 'blob:first-preview')
+    expect(screen.getByRole('button', { name: 'previousImage' }).parentElement).toBe(dialog)
+
+    const closeButton = screen.getByRole('button', { name: 'closeImagePreview' })
+    expect(closeButton.parentElement).toBe(dialog)
+    expect(closeButton).toHaveClass('fixed')
+    expect(imageStage).not.toContainElement(closeButton)
 
     fireEvent.click(screen.getByRole('button', { name: 'closeImagePreview' }))
     expect(screen.queryByRole('dialog', { name: 'imagePreviewDialog' })).not.toBeInTheDocument()

--- a/tests/options/PromptFormAttachments.test.tsx
+++ b/tests/options/PromptFormAttachments.test.tsx
@@ -15,7 +15,10 @@ vi.mock('@/utils/categoryUtils', () => ({
 }))
 
 vi.mock('@/utils/attachments/fileSystem', () => ({
+  getAttachmentStorageMode: vi.fn().mockResolvedValue('external'),
   getAttachmentRootHandle: vi.fn().mockResolvedValue({ name: 'root' }),
+  pickAndStoreAttachmentRoot: vi.fn().mockResolvedValue({ name: 'root' }),
+  useInternalAttachmentStorage: vi.fn().mockResolvedValue({ name: 'internal-root' }),
   verifyReadWritePermission: vi.fn().mockResolvedValue(true),
   removeAttachmentDirectoryFromRoot: vi.fn(),
   removeAttachmentFileFromRoot: vi.fn(),

--- a/tests/options/PromptFormAttachments.test.tsx
+++ b/tests/options/PromptFormAttachments.test.tsx
@@ -94,4 +94,22 @@ describe('PromptForm attachments', () => {
       }))
     })
   })
+
+  it('uses prompt source URL translation keys for the URL field', async () => {
+    render(
+      <PromptForm
+        onSubmit={vi.fn()}
+        initialData={null}
+        onCancel={vi.fn()}
+        isEditing={false}
+      />
+    )
+
+    await screen.findByLabelText('titleLabel')
+
+    expect(screen.getByText('promptSourceUrlLabel')).toBeInTheDocument()
+    expect(screen.getByText(/promptSourceUrlOptional/)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('promptSourceUrlPlaceholder')).toBeInTheDocument()
+    expect(screen.queryByText('thumbnailUrlLabel')).not.toBeInTheDocument()
+  })
 })

--- a/tests/options/PromptFormAttachments.test.tsx
+++ b/tests/options/PromptFormAttachments.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 vi.mock('@/utils/categoryUtils', () => ({
@@ -46,6 +46,11 @@ describe('PromptForm attachments', () => {
       relativePath: `attachments/${promptId}/att-1-${file.name}`,
       createdAt: '2024-01-01T00:00:00.000Z',
     }))
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('uses an internally generated prompt id when adding attachments to a new prompt', async () => {
@@ -111,5 +116,52 @@ describe('PromptForm attachments', () => {
     expect(screen.getByText(/promptSourceUrlOptional/)).toBeInTheDocument()
     expect(screen.getByPlaceholderText('promptSourceUrlPlaceholder')).toBeInTheDocument()
     expect(screen.queryByText('thumbnailUrlLabel')).not.toBeInTheDocument()
+  })
+
+  it('fetches promptSourceUrl preview on blur and submits the base64 preview data', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(fetch).mockResolvedValue(new Response('preview', {
+      headers: { 'content-type': 'image/png' },
+    }))
+
+    render(
+      <PromptForm
+        onSubmit={onSubmit}
+        initialData={null}
+        onCancel={vi.fn()}
+        isEditing={false}
+      />
+    )
+
+    await screen.findByLabelText('titleLabel')
+
+    fireEvent.change(screen.getByLabelText('titleLabel'), {
+      target: { value: 'Prompt with source' },
+    })
+    fireEvent.change(screen.getByLabelText('contentLabel'), {
+      target: { value: 'Prompt content' },
+    })
+    fireEvent.change(screen.getByLabelText(/promptSourceUrlLabel/), {
+      target: { value: 'https://example.cn/prompt-source' },
+    })
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(screen.queryByRole('img', { name: 'promptSourceUrlPreviewAlt' })).not.toBeInTheDocument()
+
+    fireEvent.blur(screen.getByLabelText(/promptSourceUrlLabel/))
+
+    const preview = await screen.findByRole('img', { name: 'promptSourceUrlPreviewAlt' })
+    expect(preview).toHaveAttribute('src', 'data:image/png;base64,cHJldmlldw==')
+    expect(fetch).toHaveBeenCalledWith('https://example.cn/prompt-source')
+
+    fireEvent.click(screen.getByRole('button', { name: 'savePromptButton' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        promptSourceUrl: 'https://example.cn/prompt-source',
+        promptSourcePreviewDataUrl: 'data:image/png;base64,cHJldmlldw==',
+      }))
+    })
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty('thumbnailUrl')
   })
 })

--- a/tests/options/PromptManagerAttachments.test.tsx
+++ b/tests/options/PromptManagerAttachments.test.tsx
@@ -25,6 +25,7 @@ const operations = await import('@/utils/attachments/promptAttachmentOperations'
 const {
   buildPromptDuplicate,
   deletePromptWithAttachments,
+  formatPromptBackupFileName,
 } = await import('@/entrypoints/options/components/PromptManager')
 
 const createAttachment = (overrides: Partial<PromptAttachment> = {}): PromptAttachment => ({
@@ -95,5 +96,11 @@ describe('PromptManager attachment lifecycle helpers', () => {
     })
 
     vi.restoreAllMocks()
+  })
+
+  it('formats prompt backup export file names with compact local timestamps', () => {
+    expect(formatPromptBackupFileName(new Date(2026, 3, 30, 9, 4, 5))).toBe(
+      'quick-prompt-backup-20260430090405.zip'
+    )
   })
 })

--- a/tests/options/SortablePromptCard.test.tsx
+++ b/tests/options/SortablePromptCard.test.tsx
@@ -158,6 +158,20 @@ describe("SortablePromptCard", () => {
     expect(screen.getByText(/createdAt:/)).toBeInTheDocument();
   });
 
+  it("renders promptSourceUrl as a source link and image preview", () => {
+    renderCard(vi.fn(), false, {
+      promptSourceUrl: "https://cdn.example.cn/prompt-source",
+      promptSourcePreviewDataUrl: "data:image/png;base64,saved-preview",
+    });
+
+    const sourceLink = screen.getByRole("link", { name: "promptSourceUrlLabel" });
+    const preview = screen.getByRole("img", { name: "promptSourceUrlPreviewAlt" });
+
+    expect(sourceLink).toHaveAttribute("href", "https://cdn.example.cn/prompt-source");
+    expect(sourceLink).toHaveAttribute("target", "_blank");
+    expect(preview).toHaveAttribute("src", "data:image/png;base64,saved-preview");
+  });
+
   it("allows compact layout title and content to wrap with independent card heights", () => {
     renderCard(vi.fn(), true, {
       title: "Long compact title ".repeat(12),

--- a/tests/utils/promptBackupArchive.test.ts
+++ b/tests/utils/promptBackupArchive.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Category, PromptItem } from "@/utils/types";
+import { WEBDAV_FILENAME } from "@/utils/sync/webdavSync";
+import {
+  createPromptBackupZip,
+  mergePromptBackupCategories,
+  parsePromptBackupBlob,
+  restorePromptBackupAttachments,
+} from "@/utils/promptBackupArchive";
+import { readZipArchive } from "@/utils/zipArchive";
+
+vi.mock("@/utils/attachments/fileSystem", () => ({
+  copyFileToAttachmentRoot: vi.fn(),
+  getFileFromAttachmentRoot: vi.fn(),
+}));
+
+const fileSystem = await import("@/utils/attachments/fileSystem");
+const textDecoder = new TextDecoder();
+
+const rootHandle = { name: "attachments" } as FileSystemDirectoryHandle;
+
+const createCategory = (overrides: Partial<Category> = {}): Category => ({
+  id: "default",
+  name: "Default",
+  enabled: true,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const createPrompt = (overrides: Partial<PromptItem> = {}): PromptItem => ({
+  id: "prompt-1",
+  title: "Prompt",
+  content: "Content",
+  tags: ["tag"],
+  enabled: true,
+  categoryId: "default",
+  lastModified: "2024-01-01T00:00:00.000Z",
+  attachments: [
+    {
+      id: "attachment-1",
+      name: "guide.pdf",
+      type: "application/pdf",
+      size: 11,
+      relativePath: "attachments/prompt-1/attachment-1-guide.pdf",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    },
+  ],
+  ...overrides,
+});
+
+describe("prompt backup archive helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exports a full zip backup with manifest, prompt files, categories, and attachments", async () => {
+    const prompt = createPrompt();
+    const categories = [createCategory()];
+    vi.mocked(fileSystem.getFileFromAttachmentRoot).mockResolvedValue(
+      new File(["pdf content"], "guide.pdf", { type: "application/pdf" })
+    );
+
+    const archive = await createPromptBackupZip(rootHandle, [prompt], categories);
+    const entries = await readZipArchive(archive);
+    const entryPaths = entries.map((entry) => entry.path);
+
+    expect(entryPaths).toEqual([
+      "prompts/",
+      "attachments/",
+      "attachments/prompt-1/attachment-1-guide.pdf",
+      "prompts/prompt-1.json",
+      WEBDAV_FILENAME,
+    ]);
+
+    const manifest = JSON.parse(textDecoder.decode(entries.find((entry) => entry.path === WEBDAV_FILENAME)?.data));
+    expect(manifest).toMatchObject({
+      storageFormat: "prompt-files",
+      categories,
+      promptFiles: [expect.objectContaining({ id: "prompt-1", path: "prompts/prompt-1.json" })],
+    });
+
+    const promptFile = JSON.parse(textDecoder.decode(entries.find((entry) => entry.path === "prompts/prompt-1.json")?.data));
+    expect(promptFile).toMatchObject({ prompt });
+    expect(textDecoder.decode(entries.find((entry) => entry.path === "attachments/prompt-1/attachment-1-guide.pdf")?.data)).toBe("pdf content");
+  });
+
+  it("parses a zip backup and restores attachment files", async () => {
+    const prompt = createPrompt();
+    vi.mocked(fileSystem.getFileFromAttachmentRoot).mockResolvedValue(
+      new File(["pdf content"], "guide.pdf", { type: "application/pdf" })
+    );
+    const archive = await createPromptBackupZip(rootHandle, [prompt], [createCategory()]);
+
+    const parsed = await parsePromptBackupBlob(archive);
+    expect(parsed.prompts).toEqual([expect.objectContaining({ id: "prompt-1", attachments: prompt.attachments })]);
+    expect(parsed.categories).toEqual([expect.objectContaining({ id: "default" })]);
+    expect(parsed.attachmentFiles).toHaveLength(1);
+
+    await restorePromptBackupAttachments(rootHandle, parsed.attachmentFiles);
+
+    expect(fileSystem.copyFileToAttachmentRoot).toHaveBeenCalledWith(
+      rootHandle,
+      "attachments/prompt-1/attachment-1-guide.pdf",
+      expect.any(File)
+    );
+  });
+
+  it("parses legacy prompt JSON arrays and migrates thumbnailUrl to promptSourceUrl", async () => {
+    const legacyJson = JSON.stringify([
+      {
+        id: "legacy-prompt",
+        title: "Legacy",
+        content: "Content",
+        tags: [],
+        enabled: true,
+        categoryId: "default",
+        thumbnailUrl: "https://example.com/source.png",
+      },
+    ]);
+
+    const parsed = await parsePromptBackupBlob(new Blob([legacyJson], { type: "application/json" }));
+
+    expect(parsed.sourceFormat).toBe("json");
+    expect(parsed.prompts).toEqual([
+      expect.objectContaining({
+        id: "legacy-prompt",
+        promptSourceUrl: "https://example.com/source.png",
+      }),
+    ]);
+    expect(parsed.categories).toEqual([]);
+    expect(parsed.attachmentFiles).toEqual([]);
+  });
+
+  it("merges backup categories by id and reports added and updated counts", () => {
+    const existing = createCategory({ id: "default", name: "Default" });
+    const result = mergePromptBackupCategories(
+      [existing],
+      [
+        createCategory({ id: "default", name: "Default updated" }),
+        createCategory({ id: "painting", name: "Painting" }),
+      ]
+    );
+
+    expect(result.addedCount).toBe(1);
+    expect(result.updatedCount).toBe(1);
+    expect(result.categories).toEqual([
+      expect.objectContaining({ id: "default", name: "Default updated" }),
+      expect.objectContaining({ id: "painting", name: "Painting" }),
+    ]);
+  });
+});

--- a/tests/utils/promptSourcePreview.test.ts
+++ b/tests/utils/promptSourcePreview.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPromptSourcePreviewCandidates,
+  fetchPromptSourcePreviewDataUrl,
+  getPromptSourceDomainName,
+} from '@/utils/promptSourcePreview'
+
+describe('promptSourcePreview', () => {
+  it('builds direct, favicon, and placeholder preview candidates', () => {
+    expect(buildPromptSourcePreviewCandidates('https://cdn.example.cn/prompts/source')).toEqual([
+      'https://cdn.example.cn/prompts/source',
+      'https://cdn.example.cn/favicon.ico',
+      'https://placehold.co/80x80/6366f1/white?text=example.cn',
+    ])
+  })
+
+  it('uses the registrable domain for placeholder text', () => {
+    expect(getPromptSourceDomainName('https://www.assets.example.co.uk/prompt')).toBe('example.co.uk')
+    expect(getPromptSourceDomainName('https://sub.example.cn/prompt')).toBe('example.cn')
+  })
+
+  it('fetches the first image candidate as a base64 data URL', async () => {
+    const fetcher = async (url: string) => {
+      if (url === 'https://example.cn/prompt') {
+        return new Response('not an image', {
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      return new Response('favicon', {
+        headers: { 'content-type': 'image/png' },
+      })
+    }
+
+    await expect(fetchPromptSourcePreviewDataUrl('https://example.cn/prompt', fetcher)).resolves.toBe(
+      'data:image/png;base64,ZmF2aWNvbg=='
+    )
+  })
+})

--- a/tests/utils/promptUtils.test.ts
+++ b/tests/utils/promptUtils.test.ts
@@ -310,6 +310,16 @@ describe('normalizePromptItem', () => {
     expect(normalized.attachments).toEqual(attachments)
   })
 
+  it('应该将旧的 thumbnailUrl 迁移为 promptSourceUrl', () => {
+    const normalized = normalizePromptItem({
+      ...createPrompt(),
+      thumbnailUrl: 'https://example.com/legacy-source',
+    } as PromptItem & { thumbnailUrl: string })
+
+    expect(normalized.promptSourceUrl).toBe('https://example.com/legacy-source')
+    expect(normalized).not.toHaveProperty('thumbnailUrl')
+  })
+
   vi.useRealTimers()
 })
 

--- a/tests/utils/zipArchive.test.ts
+++ b/tests/utils/zipArchive.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  createZipArchive,
+  isZipArchiveData,
+  readBlobAsUint8Array,
+  readZipArchive,
+} from "@/utils/zipArchive";
+
+const textDecoder = new TextDecoder();
+
+describe("zip archive helpers", () => {
+  it("creates a readable zip archive with text and binary entries", async () => {
+    const archive = await createZipArchive([
+      { path: "quick-prompt-backup.json", data: JSON.stringify({ ok: true }) },
+      { path: "prompts/prompt-1.json", data: new TextEncoder().encode("prompt") },
+      { path: "attachments/prompt-1/file.bin", data: new Uint8Array([1, 2, 3]) },
+    ]);
+
+    const bytes = await readBlobAsUint8Array(archive);
+    expect(isZipArchiveData(bytes)).toBe(true);
+
+    const entries = await readZipArchive(archive);
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "quick-prompt-backup.json",
+      "prompts/prompt-1.json",
+      "attachments/prompt-1/file.bin",
+    ]);
+    expect(textDecoder.decode(entries[1].data)).toBe("prompt");
+    expect(Array.from(entries[2].data)).toEqual([1, 2, 3]);
+  });
+});

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -50,7 +50,6 @@ export const DEFAULT_PROMPTS: PromptItem[] = [
     tags: ["画图", "吉卜力"],
     enabled: true,
     categoryId: "painting",
-    thumbnailUrl: "https://placehold.co/80x80/f59e0b/white?text=Ghibli",
   },
   {
     id: "default-code-explain",
@@ -59,7 +58,6 @@ export const DEFAULT_PROMPTS: PromptItem[] = [
     tags: ["编程"],
     enabled: true,
     categoryId: "programming",
-    thumbnailUrl: "https://placehold.co/80x80/10b981/white?text=Code",
   },
   {
     id: "default-role-template",
@@ -68,6 +66,5 @@ export const DEFAULT_PROMPTS: PromptItem[] = [
     tags: ["编程", "变量"],
     enabled: true,
     categoryId: "programming",
-    thumbnailUrl: "https://placehold.co/80x80/6366f1/white?text=Role",
   },
 ];

--- a/utils/promptBackupArchive.ts
+++ b/utils/promptBackupArchive.ts
@@ -1,0 +1,305 @@
+import type { Category, PromptAttachment, PromptItem } from "@/utils/types";
+import { ATTACHMENTS_DIR_NAME } from "@/utils/attachments/metadata";
+import {
+  type AttachmentStorageRootHandle,
+  copyFileToAttachmentRoot,
+  getFileFromAttachmentRoot,
+} from "@/utils/attachments/fileSystem";
+import {
+  WEBDAV_FILENAME,
+  buildWebDavPromptFileReference,
+  deserializeFromWebDavContent,
+  deserializeWebDavPromptContent,
+  serializeWebDavManifestContent,
+  serializeWebDavPromptContent,
+} from "@/utils/sync/webdavSync";
+import { validateAndNormalizePrompts } from "@/utils/promptUtils";
+import {
+  createZipArchive,
+  isZipArchiveData,
+  readBlobAsUint8Array,
+  readZipArchive,
+  type ZipArchiveEntry,
+  type ZipArchiveInputEntry,
+} from "@/utils/zipArchive";
+
+export type PromptBackupSourceFormat = "json" | "zip";
+
+export interface PromptBackupAttachmentFile {
+  relativePath: string;
+  file: File;
+}
+
+export interface ParsedPromptBackup {
+  sourceFormat: PromptBackupSourceFormat;
+  prompts: PromptItem[];
+  categories: Category[];
+  attachmentFiles: PromptBackupAttachmentFile[];
+}
+
+export interface CategoryMergeResult {
+  categories: Category[];
+  addedCount: number;
+  updatedCount: number;
+}
+
+const textDecoder = new TextDecoder();
+
+const getErrorMessage = (error: unknown): string => (
+  error instanceof Error ? error.message : String(error)
+);
+
+const getPromptAttachments = (prompt: PromptItem): PromptAttachment[] => (
+  Array.isArray(prompt.attachments) ? prompt.attachments : []
+);
+
+const normalizeBackupPath = (path: string): string => {
+  const normalizedPath = path.replace(/\\/g, "/").replace(/^\/+/, "");
+  const segments = normalizedPath.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    throw new Error("Backup path is empty");
+  }
+
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("Backup path is outside the archive root");
+  }
+
+  return `${segments.join("/")}${normalizedPath.endsWith("/") ? "/" : ""}`;
+};
+
+const isDirectoryEntry = (path: string): boolean => path.endsWith("/");
+
+const isAttachmentPath = (path: string): boolean => (
+  path.startsWith(`${ATTACHMENTS_DIR_NAME}/`) && !isDirectoryEntry(path)
+);
+
+const getFileNameFromPath = (path: string): string => (
+  path.split("/").filter(Boolean).at(-1) || "attachment"
+);
+
+const createFileFromBytes = (path: string, data: Uint8Array, type?: string): File => (
+  new File([data], getFileNameFromPath(path), {
+    type: type || "application/octet-stream",
+  })
+);
+
+const normalizeBackupCategories = (categories: unknown): Category[] => {
+  if (!Array.isArray(categories)) {
+    return [];
+  }
+
+  return categories
+    .filter((category): category is Partial<Category> => (
+      typeof category === "object" &&
+      category !== null &&
+      typeof (category as Category).id === "string" &&
+      typeof (category as Category).name === "string"
+    ))
+    .map((category) => {
+      const now = new Date().toISOString();
+
+      return {
+        id: category.id!,
+        name: category.name!,
+        description: typeof category.description === "string" ? category.description : "",
+        color: typeof category.color === "string" ? category.color : "#6366f1",
+        enabled: typeof category.enabled === "boolean" ? category.enabled : true,
+        createdAt: typeof category.createdAt === "string" ? category.createdAt : now,
+        updatedAt: typeof category.updatedAt === "string" ? category.updatedAt : now,
+      };
+    });
+};
+
+export const mergePromptBackupCategories = (
+  existingCategories: Category[],
+  importedCategories: Category[]
+): CategoryMergeResult => {
+  const categoriesMap = new Map(existingCategories.map((category) => [category.id, category]));
+  let addedCount = 0;
+  let updatedCount = 0;
+
+  importedCategories.forEach((category) => {
+    const existingCategory = categoriesMap.get(category.id);
+
+    if (!existingCategory) {
+      categoriesMap.set(category.id, category);
+      addedCount += 1;
+      return;
+    }
+
+    const updatedCategory = { ...existingCategory, ...category };
+    const { updatedAt: _existingUpdatedAt, ...existingComparable } = existingCategory;
+    const { updatedAt: _updatedAt, ...updatedComparable } = updatedCategory;
+
+    if (JSON.stringify(existingComparable) !== JSON.stringify(updatedComparable)) {
+      categoriesMap.set(category.id, updatedCategory);
+      updatedCount += 1;
+    }
+  });
+
+  return {
+    categories: Array.from(categoriesMap.values()),
+    addedCount,
+    updatedCount,
+  };
+};
+
+const getAttachmentTypeByPath = (prompts: PromptItem[]): Map<string, string> => (
+  new Map(
+    prompts
+      .flatMap(getPromptAttachments)
+      .map((attachment) => [normalizeBackupPath(attachment.relativePath), attachment.type])
+  )
+);
+
+const getReferencedAttachmentPaths = (prompts: PromptItem[]): string[] => (
+  Array.from(new Set(
+    prompts
+      .flatMap(getPromptAttachments)
+      .map((attachment) => normalizeBackupPath(attachment.relativePath))
+      .filter(isAttachmentPath)
+  ))
+);
+
+export const createPromptBackupZip = async (
+  rootHandle: AttachmentStorageRootHandle | undefined,
+  prompts: PromptItem[],
+  categories: Category[]
+): Promise<Blob> => {
+  const entries: ZipArchiveInputEntry[] = [
+    { path: "prompts/", data: new Uint8Array() },
+  ];
+  const attachmentPaths = getReferencedAttachmentPaths(prompts);
+
+  if (attachmentPaths.length > 0) {
+    if (!rootHandle) {
+      throw new Error("Attachment root is required to export attachment files");
+    }
+
+    entries.push({ path: `${ATTACHMENTS_DIR_NAME}/`, data: new Uint8Array() });
+
+    for (const relativePath of attachmentPaths) {
+      try {
+        entries.push({
+          path: relativePath,
+          data: await getFileFromAttachmentRoot(rootHandle, relativePath),
+        });
+      } catch (error) {
+        throw new Error(`${relativePath}: ${getErrorMessage(error)}`);
+      }
+    }
+  }
+
+  prompts.forEach((prompt) => {
+    const promptFile = buildWebDavPromptFileReference(prompt);
+    entries.push({
+      path: promptFile.path,
+      data: serializeWebDavPromptContent(prompt),
+    });
+  });
+
+  entries.push({
+    path: WEBDAV_FILENAME,
+    data: serializeWebDavManifestContent(prompts, categories),
+  });
+
+  return createZipArchive(entries);
+};
+
+const buildEntryMap = (entries: ZipArchiveEntry[]): Map<string, ZipArchiveEntry> => (
+  new Map(entries.map((entry) => [normalizeBackupPath(entry.path), {
+    ...entry,
+    path: normalizeBackupPath(entry.path),
+  }]))
+);
+
+const parseJsonBackup = (content: string): ParsedPromptBackup => {
+  const data = JSON.parse(content);
+
+  if (Array.isArray(data)) {
+    return {
+      sourceFormat: "json",
+      prompts: validateAndNormalizePrompts(data),
+      categories: [],
+      attachmentFiles: [],
+    };
+  }
+
+  const backup = deserializeFromWebDavContent(content);
+
+  return {
+    sourceFormat: "json",
+    prompts: validateAndNormalizePrompts(backup.prompts),
+    categories: normalizeBackupCategories(backup.categories),
+    attachmentFiles: [],
+  };
+};
+
+const parseZipBackup = async (bytes: Uint8Array): Promise<ParsedPromptBackup> => {
+  const entries = await readZipArchive(bytes);
+  const entryMap = buildEntryMap(entries);
+  const manifestEntry = entryMap.get(WEBDAV_FILENAME);
+
+  if (!manifestEntry) {
+    throw new Error(`Backup zip is missing ${WEBDAV_FILENAME}`);
+  }
+
+  const backup = deserializeFromWebDavContent(textDecoder.decode(manifestEntry.data));
+  const prompts = backup.promptFiles?.length
+    ? backup.promptFiles.map((promptFile) => {
+      const promptPath = normalizeBackupPath(promptFile.path);
+      const promptEntry = entryMap.get(promptPath);
+
+      if (!promptEntry) {
+        throw new Error(`Backup zip is missing ${promptPath}`);
+      }
+
+      return deserializeWebDavPromptContent(textDecoder.decode(promptEntry.data));
+    })
+    : backup.prompts;
+  const normalizedPrompts = validateAndNormalizePrompts(prompts);
+  const attachmentTypeByPath = getAttachmentTypeByPath(normalizedPrompts);
+  const attachmentFiles = getReferencedAttachmentPaths(normalizedPrompts).map((relativePath) => {
+    const attachmentEntry = entryMap.get(relativePath);
+
+    if (!attachmentEntry) {
+      throw new Error(`Backup zip is missing ${relativePath}`);
+    }
+
+    return {
+      relativePath,
+      file: createFileFromBytes(relativePath, attachmentEntry.data, attachmentTypeByPath.get(relativePath)),
+    };
+  });
+
+  return {
+    sourceFormat: "zip",
+    prompts: normalizedPrompts,
+    categories: normalizeBackupCategories(backup.categories),
+    attachmentFiles,
+  };
+};
+
+export const parsePromptBackupBlob = async (source: Blob | ArrayBuffer | Uint8Array): Promise<ParsedPromptBackup> => {
+  const bytes = source instanceof Blob
+    ? await readBlobAsUint8Array(source)
+    : ArrayBuffer.isView(source)
+      ? new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+      : new Uint8Array(source);
+
+  if (isZipArchiveData(bytes)) {
+    return parseZipBackup(bytes);
+  }
+
+  return parseJsonBackup(textDecoder.decode(bytes));
+};
+
+export const restorePromptBackupAttachments = async (
+  rootHandle: AttachmentStorageRootHandle,
+  attachmentFiles: PromptBackupAttachmentFile[]
+): Promise<void> => {
+  for (const attachmentFile of attachmentFiles) {
+    await copyFileToAttachmentRoot(rootHandle, attachmentFile.relativePath, attachmentFile.file);
+  }
+};

--- a/utils/promptSourcePreview.ts
+++ b/utils/promptSourcePreview.ts
@@ -1,0 +1,116 @@
+const PROMPT_SOURCE_PLACEHOLDER_BASE_URL = 'https://placehold.co/80x80/6366f1/white'
+
+const MULTI_PART_PUBLIC_SUFFIXES = new Set([
+  'ac.cn',
+  'com.au',
+  'com.br',
+  'com.cn',
+  'com.hk',
+  'com.mx',
+  'com.tw',
+  'co.jp',
+  'co.kr',
+  'co.nz',
+  'co.uk',
+  'gov.cn',
+  'gov.uk',
+  'ne.jp',
+  'net.au',
+  'net.cn',
+  'or.jp',
+  'org.au',
+  'org.cn',
+  'org.uk',
+])
+
+const parsePromptSourceUrl = (url: string): URL | null => {
+  try {
+    return new URL(url.trim())
+  } catch {
+    return null
+  }
+}
+
+const BASE64_CHUNK_SIZE = 0x6000
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer)
+  const chunks: string[] = []
+
+  for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_SIZE) {
+    const chunk = bytes.subarray(offset, offset + BASE64_CHUNK_SIZE)
+    let binary = ''
+
+    for (let index = 0; index < chunk.length; index++) {
+      binary += String.fromCharCode(chunk[index])
+    }
+
+    chunks.push(btoa(binary))
+  }
+
+  return chunks.join('')
+}
+
+export const getPromptSourceDomainName = (url: string): string => {
+  const parsed = parsePromptSourceUrl(url)
+  if (!parsed) return ''
+
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, '').replace(/^www\./, '')
+  const labels = hostname.split('.').filter(Boolean)
+
+  if (labels.length <= 2) {
+    return labels.join('.')
+  }
+
+  const publicSuffix = labels.slice(-2).join('.')
+  if (MULTI_PART_PUBLIC_SUFFIXES.has(publicSuffix) && labels.length >= 3) {
+    return labels.slice(-3).join('.')
+  }
+
+  return labels.slice(-2).join('.')
+}
+
+export const buildPromptSourcePreviewCandidates = (url: string): string[] => {
+  const directUrl = url.trim()
+  if (!directUrl) return []
+
+  const candidates = [directUrl]
+  const parsed = parsePromptSourceUrl(directUrl)
+
+  if (parsed && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+    candidates.push(new URL('/favicon.ico', parsed.origin).toString())
+
+    const domainName = getPromptSourceDomainName(directUrl)
+    if (domainName) {
+      candidates.push(`${PROMPT_SOURCE_PLACEHOLDER_BASE_URL}?text=${encodeURIComponent(domainName)}`)
+    }
+  }
+
+  return Array.from(new Set(candidates))
+}
+
+export const fetchPromptSourcePreviewDataUrl = async (
+  url: string,
+  fetcher: (url: string) => Promise<Response> = fetch
+): Promise<string | undefined> => {
+  for (const candidate of buildPromptSourcePreviewCandidates(url)) {
+    try {
+      const response = await fetcher(candidate)
+      if (!response.ok) continue
+
+      const contentType = (
+        response.headers.get('content-type')?.split(';')[0].trim() ||
+        ''
+      )
+
+      if (!contentType.startsWith('image/')) continue
+
+      const base64 = arrayBufferToBase64(await response.arrayBuffer())
+      return `data:${contentType};base64,${base64}`
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return undefined
+}

--- a/utils/promptUtils.ts
+++ b/utils/promptUtils.ts
@@ -154,9 +154,16 @@ export const isValidPromptItem = (prompt: unknown): prompt is PromptItem => {
  */
 export const normalizePromptItem = (prompt: PromptItem): PromptItem => {
   const promptWithAttachments = normalizePromptAttachments(prompt)
+  const {
+    thumbnailUrl: legacyThumbnailUrl,
+    promptSourceUrl,
+    ...promptWithoutLegacyThumbnail
+  } = promptWithAttachments as PromptItem & { thumbnailUrl?: string }
+  const normalizedPromptSourceUrl = promptSourceUrl || legacyThumbnailUrl
 
   return {
-    ...promptWithAttachments,
+    ...promptWithoutLegacyThumbnail,
+    ...(normalizedPromptSourceUrl ? { promptSourceUrl: normalizedPromptSourceUrl } : {}),
     categoryId: prompt.categoryId || DEFAULT_CATEGORY_ID,
     enabled: prompt.enabled !== undefined ? prompt.enabled : true,
     createdAt: prompt.createdAt || prompt.lastModified || new Date().toISOString(),

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -40,7 +40,8 @@ export interface PromptItem {
   createdAt?: string; // 创建时间（ISO 字符串）
   lastModified?: string; // 最后修改时间（ISO 字符串）
   sortOrder?: number; // 排序字段，用于拖拽排序
-  thumbnailUrl?: string; // 缩略图 URL
+  promptSourceUrl?: string; // 提示词来源 URL
+  promptSourcePreviewDataUrl?: string; // 提示词来源 URL 预览图 data URL
   attachments?: PromptAttachment[];
 }
 

--- a/utils/zipArchive.ts
+++ b/utils/zipArchive.ts
@@ -1,0 +1,333 @@
+export interface ZipArchiveInputEntry {
+  path: string;
+  data: string | Uint8Array | ArrayBuffer | Blob;
+}
+
+export interface ZipArchiveEntry {
+  path: string;
+  data: Uint8Array;
+}
+
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_DIRECTORY_HEADER_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const ZIP_VERSION_NEEDED = 20;
+const ZIP_UTF8_FLAG = 0x0800;
+const ZIP_STORE_METHOD = 0;
+const ZIP_DEFLATE_METHOD = 8;
+const DOS_DATE_1980_01_01 = 0x0021;
+const DOS_TIME_MIDNIGHT = 0x0000;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+let crc32Table: Uint32Array | null = null;
+
+const getCrc32Table = (): Uint32Array => {
+  if (crc32Table) {
+    return crc32Table;
+  }
+
+  const table = new Uint32Array(256);
+
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+    }
+
+    table[index] = value >>> 0;
+  }
+
+  crc32Table = table;
+  return table;
+};
+
+const getCrc32 = (data: Uint8Array): number => {
+  const table = getCrc32Table();
+  let crc = 0xffffffff;
+
+  for (const byte of data) {
+    crc = table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const writeUint16 = (target: Uint8Array, offset: number, value: number): void => {
+  target[offset] = value & 0xff;
+  target[offset + 1] = (value >>> 8) & 0xff;
+};
+
+const writeUint32 = (target: Uint8Array, offset: number, value: number): void => {
+  target[offset] = value & 0xff;
+  target[offset + 1] = (value >>> 8) & 0xff;
+  target[offset + 2] = (value >>> 16) & 0xff;
+  target[offset + 3] = (value >>> 24) & 0xff;
+};
+
+const getUint16 = (view: DataView, offset: number): number => (
+  view.getUint16(offset, true)
+);
+
+const getUint32 = (view: DataView, offset: number): number => (
+  view.getUint32(offset, true)
+);
+
+const normalizeArchivePath = (path: string): string => {
+  const normalizedPath = path.replace(/\\/g, "/").replace(/^\/+/, "");
+
+  if (!normalizedPath) {
+    throw new Error("ZIP entry path is required");
+  }
+
+  return normalizedPath;
+};
+
+export const readBlobAsUint8Array = async (blob: Blob): Promise<Uint8Array> => {
+  if (typeof blob.arrayBuffer === "function") {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+};
+
+const toUint8Array = async (data: ZipArchiveInputEntry["data"]): Promise<Uint8Array> => {
+  if (typeof data === "string") {
+    return textEncoder.encode(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  return readBlobAsUint8Array(data);
+};
+
+interface PreparedZipEntry {
+  path: string;
+  nameBytes: Uint8Array;
+  data: Uint8Array;
+  crc32: number;
+  localHeaderOffset: number;
+}
+
+const createLocalHeader = (entry: PreparedZipEntry): Uint8Array => {
+  const header = new Uint8Array(30);
+
+  writeUint32(header, 0, LOCAL_FILE_HEADER_SIGNATURE);
+  writeUint16(header, 4, ZIP_VERSION_NEEDED);
+  writeUint16(header, 6, ZIP_UTF8_FLAG);
+  writeUint16(header, 8, ZIP_STORE_METHOD);
+  writeUint16(header, 10, DOS_TIME_MIDNIGHT);
+  writeUint16(header, 12, DOS_DATE_1980_01_01);
+  writeUint32(header, 14, entry.crc32);
+  writeUint32(header, 18, entry.data.byteLength);
+  writeUint32(header, 22, entry.data.byteLength);
+  writeUint16(header, 26, entry.nameBytes.byteLength);
+  writeUint16(header, 28, 0);
+
+  return header;
+};
+
+const createCentralDirectoryHeader = (entry: PreparedZipEntry): Uint8Array => {
+  const header = new Uint8Array(46);
+
+  writeUint32(header, 0, CENTRAL_DIRECTORY_HEADER_SIGNATURE);
+  writeUint16(header, 4, ZIP_VERSION_NEEDED);
+  writeUint16(header, 6, ZIP_VERSION_NEEDED);
+  writeUint16(header, 8, ZIP_UTF8_FLAG);
+  writeUint16(header, 10, ZIP_STORE_METHOD);
+  writeUint16(header, 12, DOS_TIME_MIDNIGHT);
+  writeUint16(header, 14, DOS_DATE_1980_01_01);
+  writeUint32(header, 16, entry.crc32);
+  writeUint32(header, 20, entry.data.byteLength);
+  writeUint32(header, 24, entry.data.byteLength);
+  writeUint16(header, 28, entry.nameBytes.byteLength);
+  writeUint16(header, 30, 0);
+  writeUint16(header, 32, 0);
+  writeUint16(header, 34, 0);
+  writeUint16(header, 36, 0);
+  writeUint32(header, 38, entry.path.endsWith("/") ? 0x10 : 0);
+  writeUint32(header, 42, entry.localHeaderOffset);
+
+  return header;
+};
+
+const createEndOfCentralDirectory = (
+  entryCount: number,
+  centralDirectorySize: number,
+  centralDirectoryOffset: number
+): Uint8Array => {
+  const footer = new Uint8Array(22);
+
+  writeUint32(footer, 0, END_OF_CENTRAL_DIRECTORY_SIGNATURE);
+  writeUint16(footer, 4, 0);
+  writeUint16(footer, 6, 0);
+  writeUint16(footer, 8, entryCount);
+  writeUint16(footer, 10, entryCount);
+  writeUint32(footer, 12, centralDirectorySize);
+  writeUint32(footer, 16, centralDirectoryOffset);
+  writeUint16(footer, 20, 0);
+
+  return footer;
+};
+
+export const createZipArchive = async (entries: ZipArchiveInputEntry[]): Promise<Blob> => {
+  const chunks: Uint8Array[] = [];
+  const preparedEntries: PreparedZipEntry[] = [];
+  let offset = 0;
+
+  for (const inputEntry of entries) {
+    const path = normalizeArchivePath(inputEntry.path);
+    const data = path.endsWith("/") ? new Uint8Array() : await toUint8Array(inputEntry.data);
+    const preparedEntry: PreparedZipEntry = {
+      path,
+      nameBytes: textEncoder.encode(path),
+      data,
+      crc32: getCrc32(data),
+      localHeaderOffset: offset,
+    };
+    const localHeader = createLocalHeader(preparedEntry);
+
+    chunks.push(localHeader, preparedEntry.nameBytes, data);
+    offset += localHeader.byteLength + preparedEntry.nameBytes.byteLength + data.byteLength;
+    preparedEntries.push(preparedEntry);
+  }
+
+  const centralDirectoryOffset = offset;
+
+  for (const entry of preparedEntries) {
+    const centralDirectoryHeader = createCentralDirectoryHeader(entry);
+
+    chunks.push(centralDirectoryHeader, entry.nameBytes);
+    offset += centralDirectoryHeader.byteLength + entry.nameBytes.byteLength;
+  }
+
+  chunks.push(createEndOfCentralDirectory(
+    preparedEntries.length,
+    offset - centralDirectoryOffset,
+    centralDirectoryOffset
+  ));
+
+  return new Blob(chunks, { type: "application/zip" });
+};
+
+const findEndOfCentralDirectoryOffset = (view: DataView): number => {
+  const minimumOffset = Math.max(0, view.byteLength - 0xffff - 22);
+
+  for (let offset = view.byteLength - 22; offset >= minimumOffset; offset -= 1) {
+    if (getUint32(view, offset) === END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+      return offset;
+    }
+  }
+
+  throw new Error("ZIP archive is missing the end of central directory record");
+};
+
+const inflateRaw = async (data: Uint8Array): Promise<Uint8Array> => {
+  if (typeof DecompressionStream !== "function") {
+    throw new Error("ZIP deflate entries are not supported in this browser");
+  }
+
+  const stream = new Blob([data])
+    .stream()
+    .pipeThrough(new DecompressionStream("deflate-raw" as CompressionFormat));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+const readEntryData = async (
+  method: number,
+  compressedData: Uint8Array,
+  expectedCrc32: number,
+  expectedUncompressedSize: number
+): Promise<Uint8Array> => {
+  let data: Uint8Array;
+
+  if (method === ZIP_STORE_METHOD) {
+    data = compressedData;
+  } else if (method === ZIP_DEFLATE_METHOD) {
+    data = await inflateRaw(compressedData);
+  } else {
+    throw new Error(`Unsupported ZIP compression method: ${method}`);
+  }
+
+  if (data.byteLength !== expectedUncompressedSize) {
+    throw new Error("ZIP entry size does not match the central directory");
+  }
+
+  if (getCrc32(data) !== expectedCrc32) {
+    throw new Error("ZIP entry checksum does not match the central directory");
+  }
+
+  return data;
+};
+
+export const readZipArchive = async (source: Blob | ArrayBuffer | Uint8Array): Promise<ZipArchiveEntry[]> => {
+  const bytes = source instanceof Blob
+    ? await readBlobAsUint8Array(source)
+    : ArrayBuffer.isView(source)
+      ? new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+      : new Uint8Array(source);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const endOfCentralDirectoryOffset = findEndOfCentralDirectoryOffset(view);
+  const entryCount = getUint16(view, endOfCentralDirectoryOffset + 10);
+  const centralDirectoryOffset = getUint32(view, endOfCentralDirectoryOffset + 16);
+  const entries: ZipArchiveEntry[] = [];
+  let offset = centralDirectoryOffset;
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (getUint32(view, offset) !== CENTRAL_DIRECTORY_HEADER_SIGNATURE) {
+      throw new Error("Invalid ZIP central directory header");
+    }
+
+    const flags = getUint16(view, offset + 8);
+    const method = getUint16(view, offset + 10);
+    const crc32 = getUint32(view, offset + 16);
+    const compressedSize = getUint32(view, offset + 20);
+    const uncompressedSize = getUint32(view, offset + 24);
+    const fileNameLength = getUint16(view, offset + 28);
+    const extraFieldLength = getUint16(view, offset + 30);
+    const commentLength = getUint16(view, offset + 32);
+    const localHeaderOffset = getUint32(view, offset + 42);
+    const pathBytes = bytes.slice(offset + 46, offset + 46 + fileNameLength);
+    const path = normalizeArchivePath(
+      (flags & ZIP_UTF8_FLAG) ? textDecoder.decode(pathBytes) : textDecoder.decode(pathBytes)
+    );
+
+    if (getUint32(view, localHeaderOffset) !== LOCAL_FILE_HEADER_SIGNATURE) {
+      throw new Error("Invalid ZIP local file header");
+    }
+
+    const localFileNameLength = getUint16(view, localHeaderOffset + 26);
+    const localExtraFieldLength = getUint16(view, localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength;
+    const compressedData = bytes.slice(dataStart, dataStart + compressedSize);
+
+    entries.push({
+      path,
+      data: await readEntryData(method, compressedData, crc32, uncompressedSize),
+    });
+
+    offset += 46 + fileNameLength + extraFieldLength + commentLength;
+  }
+
+  return entries;
+};
+
+export const isZipArchiveData = (bytes: Uint8Array): boolean => (
+  bytes.byteLength >= 4 && (
+    (bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04) ||
+    (bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x05 && bytes[3] === 0x06)
+  )
+);

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       // https://developer.chrome.com/docs/extensions/how-to/integrate/oauth?hl=zh-cn#keep-consistent-id
       key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1gIStuzmtlJx9myPcEdZVB6fN6HZ4RDB2FNbhhhd1Q8kopHP3uZioJmGAbZch13CNg4nwDLzkT/Iv+SuQ92r6wEYf14rwv0pyLvegLlTWcKvpG+XfJXMl0AT32Gj2tuOoMceEpNRXZzcPf2QTftX4Lm3Kzv3kmeaIzHps1ajkT18iagllKExzmiQVZjCw/t8NYcY5cdjKQRhQqDTDqv5HnVanucEWmDPMb+AlyHOqAYxDurSt/IX1C5TW/khkCU8Fahcnw50ppVgIVKT7OLtSKDDNlqbC4BWIFWu55S5UR/CZNEbyjDtxzLkfVTi8sov7ZOUCTjEvRwjNmwXbo8PZwIDAQAB",
       permissions: ["storage", "contextMenus", "identity"],
+      host_permissions: ["http://*/*", "https://*/*"],
       oauth2: {
         // This client_id is primarily for getAuthToken (Chrome)
         client_id: `${finalChromeClientId}.apps.googleusercontent.com`,


### PR DESCRIPTION
主要修改内容：  

  - 将附件存储方式选择从设置页强制拦截，调整为首次点击上传附件时弹窗提示。
  - 附件上传后在编辑列表中展示图片缩略图。
  - 优化 `/p` 提示词弹窗中的图片附件展示，不再显示图片名称、大小和额外外层边框。
  - 点击提示词图片时打开独立大图预览层，不触发提示词插入；点击其他区域保持原有插入逻辑。
  - 移除 popup 和设置页中 Quick Prompt 图标的外层圆角/阴影样式。
  - 重命名提示词来源 URL 相关 UI 文案 key，并更新中英文翻译。