### PR TITLE
fix: add re-authorize buttons when attachment directory permission expires

### DIFF
--- a/entrypoints/options/components/GlobalSettings.tsx
+++ b/entrypoints/options/components/GlobalSettings.tsx
@@ -1,13 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { browser } from '#imports';
-import { ExternalLink, Keyboard, Languages, MousePointerClick, Settings2 } from "lucide-react";
+import { ExternalLink, FolderOpen, HardDrive, Keyboard, Languages, Loader2, MousePointerClick, Settings2, ShieldCheck } from "lucide-react";
 import { getGlobalSettings, updateGlobalSettings, type GlobalSettings } from '@/utils/globalSettings';
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { LoadingState } from "@/components/common/LoadingState";
 import { PageHeader } from "@/components/common/PageHeader";
+import {
+  type AttachmentStorageMode,
+  getAttachmentStorageMode,
+  getAttachmentRootHandle,
+  hasReadWritePermission,
+  pickAndStoreAttachmentRoot,
+  useInternalAttachmentStorage,
+} from "@/utils/attachments/fileSystem";
 import { SectionCard } from "@/components/common/SectionCard";
 import { SettingsRow } from "@/components/common/SettingsRow";
 import { PageSurface } from "@/components/layout/AppShell";
@@ -21,6 +30,9 @@ const GlobalSettingsPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [shortcuts, setShortcuts] = useState<{ [key: string]: string }>({});
+  const [storageMode, setStorageMode] = useState<AttachmentStorageMode | undefined>(undefined);
+  const [permissionExpired, setPermissionExpired] = useState(false);
+  const [isReauthorizing, setIsReauthorizing] = useState(false);
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -41,6 +53,19 @@ const GlobalSettingsPage: React.FC = () => {
           setShortcuts(shortcutMap);
         } catch (error) {
           console.warn('Unable to get shortcuts:', error);
+        }
+
+        try {
+          const mode = await getAttachmentStorageMode();
+          setStorageMode(mode);
+          if (mode === "external") {
+            const root = await getAttachmentRootHandle();
+            if (root && !(await hasReadWritePermission(root))) {
+              setPermissionExpired(true);
+            }
+          }
+        } catch (error) {
+          console.warn('Unable to load attachment storage info:', error);
         }
       } catch (error) {
         console.error('Failed to load settings:', error);
@@ -63,6 +88,48 @@ const GlobalSettingsPage: React.FC = () => {
       setSettings(prev => ({ ...prev, [key]: settings[key] }));
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const handleReauthorizeExternal = async () => {
+    if (isReauthorizing) return;
+    setIsReauthorizing(true);
+    try {
+      await pickAndStoreAttachmentRoot();
+      setPermissionExpired(false);
+      setStorageMode("external");
+    } catch (error) {
+      console.error('Failed to reauthorize attachment directory:', error);
+    } finally {
+      setIsReauthorizing(false);
+    }
+  };
+
+  const handleSwitchToInternal = async () => {
+    if (isReauthorizing) return;
+    setIsReauthorizing(true);
+    try {
+      await useInternalAttachmentStorage();
+      setStorageMode("internal");
+      setPermissionExpired(false);
+    } catch (error) {
+      console.error('Failed to switch to internal storage:', error);
+    } finally {
+      setIsReauthorizing(false);
+    }
+  };
+
+  const handleChooseExternalDirectory = async () => {
+    if (isReauthorizing) return;
+    setIsReauthorizing(true);
+    try {
+      await pickAndStoreAttachmentRoot();
+      setStorageMode("external");
+      setPermissionExpired(false);
+    } catch (error) {
+      console.error('Failed to choose attachment directory:', error);
+    } finally {
+      setIsReauthorizing(false);
     }
   };
 
@@ -183,6 +250,71 @@ const GlobalSettingsPage: React.FC = () => {
                 </button>
               ))}
             </div>
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          title={t('currentAttachmentStorageMode')}
+          description={t('currentAttachmentStorageModeDescription')}
+          contentClassName="p-0"
+        >
+          <div className="px-5 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                {storageMode === "internal" ? (
+                  <HardDrive className="size-4 text-muted-foreground" />
+                ) : (
+                  <FolderOpen className="size-4 text-muted-foreground" />
+                )}
+                <span className="text-sm font-medium text-foreground">
+                  {storageMode === "internal"
+                    ? t('attachmentStorageInternalLabel')
+                    : t('attachmentStorageExternalLabel')}
+                </span>
+              </div>
+              {storageMode === "external" ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleSwitchToInternal}
+                  disabled={isReauthorizing}
+                >
+                  {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <HardDrive className="size-3.5" />}
+                  {t('switchToInternalStorage')}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleChooseExternalDirectory}
+                  disabled={isReauthorizing}
+                >
+                  {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <FolderOpen className="size-3.5" />}
+                  {t('chooseAttachmentDirectory')}
+                </Button>
+              )}
+            </div>
+
+            {permissionExpired && (
+              <Alert variant="warning" className="mt-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <AlertDescription>{t('attachmentPermissionLost')}</AlertDescription>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleReauthorizeExternal}
+                    disabled={isReauthorizing}
+                    className="shrink-0"
+                  >
+                    {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <ShieldCheck className="size-3.5" />}
+                    {t('reauthorizeAttachmentDirectory')}
+                  </Button>
+                </div>
+              </Alert>
+            )}
           </div>
         </SectionCard>
 

--- a/entrypoints/options/components/PromptAttachmentPreview.tsx
+++ b/entrypoints/options/components/PromptAttachmentPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronLeft, ChevronRight, FileText, ImageIcon, Loader2, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, FileText, FolderOpen, HardDrive, ImageIcon, Loader2, X } from 'lucide-react'
 
 import type { PromptAttachment } from '@/utils/types'
 import { formatFileSize, isImageAttachment } from '@/utils/attachments/metadata'
@@ -7,10 +7,13 @@ import { createImageThumbnailDataUrl } from '@/utils/attachments/imageThumbnail'
 import {
   getAttachmentRootHandle,
   getFileFromAttachmentRoot,
-  hasReadWritePermission,
+  verifyReadWritePermission,
+  pickAndStoreAttachmentRoot,
+  useInternalAttachmentStorage,
 } from '@/utils/attachments/fileSystem'
 import { t } from '@/utils/i18n'
 import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 
 interface PromptAttachmentPreviewProps {
   attachments?: PromptAttachment[]
@@ -63,13 +66,18 @@ const setRuntimeThumbnailCache = (
   }
 }
 
+let lastRootPermissionFailed = false
+
 const getAuthorizedRoot = async () => {
   const root = await getAttachmentRootHandle()
+  const hasPermission = root ? await verifyReadWritePermission(root) : false
 
-  if (!root || !(await hasReadWritePermission(root))) {
+  if (!root || !hasPermission) {
+    lastRootPermissionFailed = true
     throw new Error(t('attachmentPermissionLost'))
   }
 
+  lastRootPermissionFailed = false
   return root
 }
 
@@ -124,6 +132,9 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
   const objectUrlsRef = useRef<Set<string>>(new Set())
   const [imagePreviews, setImagePreviews] = useState<Record<string, ImagePreviewState>>({})
   const [activeImageId, setActiveImageId] = useState<string | null>(null)
+  const [needsReauthorization, setNeedsReauthorization] = useState(false)
+  const [isReauthorizing, setIsReauthorizing] = useState(false)
+  const [previewRefreshKey, setPreviewRefreshKey] = useState(0)
 
   const getPreview = (attachment: PromptAttachment): ImagePreviewState | undefined => {
     const loadedPreview = imagePreviews[attachment.id]
@@ -186,6 +197,9 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
         },
       }))
     } catch {
+      if (lastRootPermissionFailed) {
+        setNeedsReauthorization(true)
+      }
       setImagePreviews((current) => ({
         ...current,
         [attachment.id]: {
@@ -219,6 +233,36 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
     void loadFullImage(nextAttachment)
   }
 
+  const handleReauthorizeExternal = async () => {
+    if (isReauthorizing) return
+    setIsReauthorizing(true)
+    try {
+      await pickAndStoreAttachmentRoot()
+      setNeedsReauthorization(false)
+      setImagePreviews({})
+      setPreviewRefreshKey((k) => k + 1)
+    } catch (err) {
+      console.error("Error reauthorizing attachment directory:", err)
+    } finally {
+      setIsReauthorizing(false)
+    }
+  }
+
+  const handleSwitchToInternal = async () => {
+    if (isReauthorizing) return
+    setIsReauthorizing(true)
+    try {
+      await useInternalAttachmentStorage()
+      setNeedsReauthorization(false)
+      setImagePreviews({})
+      setPreviewRefreshKey((k) => k + 1)
+    } catch (err) {
+      console.error("Error switching to internal storage:", err)
+    } finally {
+      setIsReauthorizing(false)
+    }
+  }
+
   useEffect(() => {
     const imageAttachments = safeAttachments.filter((attachment) => (
       isImageAttachment(attachment) && !attachment.thumbnailDataUrl
@@ -247,6 +291,9 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
           }
           nextPreviews[attachment.id] = preview
         } catch {
+          if (lastRootPermissionFailed) {
+            setNeedsReauthorization(true)
+          }
           nextPreviews[attachment.id] = { error: t('attachmentPermissionLost') }
         }
       }))
@@ -264,7 +311,7 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
       canceled = true
       objectUrls.forEach((url) => URL.revokeObjectURL(url))
     }
-  }, [safeAttachments])
+  }, [safeAttachments, previewRefreshKey])
 
   useEffect(() => {
     return () => {
@@ -278,6 +325,36 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
   }
 
   return (
+    <>
+      {needsReauthorization && (
+        <Alert variant="warning" className="mb-2">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <AlertDescription>{t('attachmentPermissionLost')}</AlertDescription>
+            <div className="flex shrink-0 gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleReauthorizeExternal}
+                disabled={isReauthorizing}
+              >
+                {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <FolderOpen className="size-3.5" />}
+                {t('reauthorizeAttachmentDirectory')}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleSwitchToInternal}
+                disabled={isReauthorizing}
+              >
+                {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <HardDrive className="size-3.5" />}
+                {t('switchToInternalStorage')}
+              </Button>
+            </div>
+          </div>
+        </Alert>
+      )}
     <div className={compact ? 'flex w-fit flex-wrap items-center gap-1.5' : 'mt-3 flex flex-wrap gap-2'}>
       {safeAttachments.map((attachment) => {
         const preview = getPreview(attachment)
@@ -407,6 +484,7 @@ const PromptAttachmentPreview: React.FC<PromptAttachmentPreviewProps> = ({
         </div>
       )}
     </div>
+    </>
   )
 }
 

--- a/entrypoints/options/components/PromptManager.tsx
+++ b/entrypoints/options/components/PromptManager.tsx
@@ -6,10 +6,13 @@ import {
   FileInput,
   FilePenLine,
   FileText,
+  FolderOpen,
   Grid2X2,
+  HardDrive,
   Library,
   Link2,
   List,
+  Loader2,
   Plus,
   Search,
   Upload,
@@ -28,6 +31,8 @@ import {
   type AttachmentStorageRootHandle,
   getAttachmentRootHandle,
   verifyReadWritePermission,
+  pickAndStoreAttachmentRoot,
+  useInternalAttachmentStorage,
 } from "@/utils/attachments/fileSystem";
 import {
   deletePromptAttachmentFiles,
@@ -149,6 +154,7 @@ const PromptManager = () => {
   const [isRemoteImporting, setIsRemoteImporting] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const [promptToDelete, setPromptToDelete] = useState<string | null>(null);
+  const [isReauthorizing, setIsReauthorizing] = useState(false);
 
   // 布局模式
   const [compactLayout, setCompactLayout] = useState<boolean>(() => {
@@ -401,6 +407,33 @@ const PromptManager = () => {
     }
 
     closeModal();
+  };
+
+  // Re-authorize attachment directory
+  const handleReauthorizeExternal = async () => {
+    if (isReauthorizing) return;
+    setIsReauthorizing(true);
+    try {
+      await pickAndStoreAttachmentRoot();
+      setError(null);
+    } catch (err) {
+      console.error("Error reauthorizing attachment directory:", err);
+    } finally {
+      setIsReauthorizing(false);
+    }
+  };
+
+  const handleSwitchToInternal = async () => {
+    if (isReauthorizing) return;
+    setIsReauthorizing(true);
+    try {
+      await useInternalAttachmentStorage();
+      setError(null);
+    } catch (err) {
+      console.error("Error switching to internal storage:", err);
+    } finally {
+      setIsReauthorizing(false);
+    }
   };
 
   // Delete a prompt
@@ -674,22 +707,52 @@ const PromptManager = () => {
     <PageSurface className="flex min-h-full flex-col">
       <div className="flex-shrink-0 space-y-4 px-4 pt-4 sm:px-6 lg:px-8">
         {error && (
-          <Alert variant="destructive">
-            <AlertCircle className="size-4" />
-            <AlertDescription className="flex items-center justify-between gap-3">
-              <span>{error}</span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setError(null)}
-                aria-label={t("close")}
-                className="text-destructive hover:bg-destructive/10"
-              >
-                <X className="size-4" />
-              </Button>
-            </AlertDescription>
-          </Alert>
+          error === t('attachmentPermissionLost') ? (
+            <Alert variant="warning">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <AlertDescription>{error}</AlertDescription>
+                <div className="flex shrink-0 gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleReauthorizeExternal}
+                    disabled={isReauthorizing}
+                  >
+                    {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <FolderOpen className="size-3.5" />}
+                    {t("reauthorizeAttachmentDirectory")}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleSwitchToInternal}
+                    disabled={isReauthorizing}
+                  >
+                    {isReauthorizing ? <Loader2 className="size-3.5 animate-spin" /> : <HardDrive className="size-3.5" />}
+                    {t("switchToInternalStorage")}
+                  </Button>
+                </div>
+              </div>
+            </Alert>
+          ) : (
+            <Alert variant="destructive">
+              <AlertCircle className="size-4" />
+              <AlertDescription className="flex items-center justify-between gap-3">
+                <span>{error}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setError(null)}
+                  aria-label={t("close")}
+                  className="text-destructive hover:bg-destructive/10"
+                >
+                  <X className="size-4" />
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )
         )}
 
         <PageHeader

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1726,6 +1726,21 @@
   "attachmentStorageReauthorized": {
     "message": "Attachment folder reauthorized."
   },
+  "currentAttachmentStorageMode": {
+    "message": "Current Attachment Storage Mode"
+  },
+  "currentAttachmentStorageModeDescription": {
+    "message": "Manage where attachments are stored and their access permissions."
+  },
+  "attachmentStorageInternalLabel": {
+    "message": "Internal Storage"
+  },
+  "attachmentStorageExternalLabel": {
+    "message": "External Folder"
+  },
+  "switchToInternalStorage": {
+    "message": "Switch to Internal Storage"
+  },
   "webdavUploadTitle": {
     "message": "Upload Local Backup"
   },

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -1726,6 +1726,21 @@
   "attachmentStorageReauthorized": {
     "message": "附件文件夹已重新授权。"
   },
+  "currentAttachmentStorageMode": {
+    "message": "当前附件存储模式"
+  },
+  "currentAttachmentStorageModeDescription": {
+    "message": "管理附件文件的存储位置和访问权限。"
+  },
+  "attachmentStorageInternalLabel": {
+    "message": "内置存储"
+  },
+  "attachmentStorageExternalLabel": {
+    "message": "外部文件夹"
+  },
+  "switchToInternalStorage": {
+    "message": "切换到内置存储"
+  },
   "webdavUploadTitle": {
     "message": "上传本地备份"
   },


### PR DESCRIPTION
When the external attachment storage directory permission expires (e.g. after browser restart), users now see actionable re-authorize buttons instead of just an error message:


- PromptManager: error banner upgraded with re-authorize and switch-to-internal buttons
- PromptAttachmentPreview: warning banner shown when permission fails during preview loading
- GlobalSettings: new attachment storage section to view mode and re-authorize from central location
- i18n: added 5 new keys for storage mode labels in zh and en locales

<img width="999" height="631" alt="PixPin_2026-05-04_10-19-34" src="https://github.com/user-attachments/assets/e8c1c64e-56df-48c5-ab2c-b09c82ff3bcf" />

Closes #59

[](https://github.com/wenyuanw/quick-prompt/issues/59)