### PR TITLE
fix: ignore composing prompt trigger input

### DIFF
--- a/entrypoints/content/index.tsx
+++ b/entrypoints/content/index.tsx
@@ -16,6 +16,7 @@ import {
   isOpenPromptSelectorShortcut,
   isSaveSelectedPromptShortcut,
 } from './utils/keyboardShortcuts'
+import { shouldOpenPromptSelectorForInput } from './utils/promptTrigger'
 
 export default defineContentScript({
   matches: ['*://*/*'],
@@ -152,7 +153,7 @@ export default defineContentScript({
       const lastValue = editableValuesMap.get(editableElement) || ''
 
       // 检查是否输入了"/p"并且弹窗尚未打开
-      if (value?.toLowerCase()?.endsWith('/p') && lastValue !== value && !isPromptSelectorOpen) {
+      if (shouldOpenPromptSelectorForInput(event as InputEvent, value, lastValue, isPromptSelectorOpen)) {
         editableValuesMap.set(editableElement, value)
         await openPromptSelector(adapter, { removePromptTrigger: true })
       } else if (!value?.toLowerCase()?.endsWith('/p')) {

--- a/entrypoints/content/index.tsx
+++ b/entrypoints/content/index.tsx
@@ -16,7 +16,10 @@ import {
   isOpenPromptSelectorShortcut,
   isSaveSelectedPromptShortcut,
 } from './utils/keyboardShortcuts'
-import { shouldOpenPromptSelectorForInput } from './utils/promptTrigger'
+import {
+  endsWithPromptTrigger,
+  shouldOpenPromptSelector,
+} from './utils/promptTrigger'
 
 export default defineContentScript({
   matches: ['*://*/*'],
@@ -141,6 +144,22 @@ export default defineContentScript({
     // 用于记录可编辑元素的最后一次内容
     const editableValuesMap = new WeakMap<HTMLElement, string>()
 
+    const tryOpenPromptSelectorForEditable = async (editableElement: HTMLElement) => {
+      const adapter = createEditableAdapter(editableElement)
+      const value = adapter.value
+      const lastValue = editableValuesMap.get(editableElement) || ''
+
+      if (shouldOpenPromptSelector(value, lastValue, isPromptSelectorOpen)) {
+        editableValuesMap.set(editableElement, value)
+        await openPromptSelector(adapter, { removePromptTrigger: true })
+        return
+      }
+
+      if (!endsWithPromptTrigger(value)) {
+        editableValuesMap.set(editableElement, value)
+      }
+    }
+
     // 监听输入框输入事件
     document.addEventListener('input', async (event) => {
       const editableElement = findEditableElement(event.target)
@@ -148,18 +167,21 @@ export default defineContentScript({
         return
       }
 
-      const adapter = createEditableAdapter(editableElement)
-      const value = adapter.value
-      const lastValue = editableValuesMap.get(editableElement) || ''
-
-      // 检查是否输入了"/p"并且弹窗尚未打开
-      if (shouldOpenPromptSelectorForInput(event as InputEvent, value, lastValue, isPromptSelectorOpen)) {
-        editableValuesMap.set(editableElement, value)
-        await openPromptSelector(adapter, { removePromptTrigger: true })
-      } else if (!value?.toLowerCase()?.endsWith('/p')) {
-        // 更新上次输入值
-        editableValuesMap.set(editableElement, value)
+      if (event instanceof InputEvent && event.isComposing) {
+        return
       }
+
+      await tryOpenPromptSelectorForEditable(editableElement)
+    })
+
+    // IME 提交后输入框可能已是 /p，但不会再触发 input 事件
+    document.addEventListener('compositionend', async (event) => {
+      const editableElement = findEditableElement(event.target)
+      if (!editableElement) {
+        return
+      }
+
+      await tryOpenPromptSelectorForEditable(editableElement)
     })
 
     // Chrome commands can be preempted by browser/OS shortcuts; keep a page-level fallback.

--- a/entrypoints/content/utils/promptTrigger.ts
+++ b/entrypoints/content/utils/promptTrigger.ts
@@ -1,3 +1,15 @@
+export const endsWithPromptTrigger = (value: string): boolean =>
+  value.toLowerCase().endsWith('/p')
+
+export const shouldOpenPromptSelector = (
+  value: string,
+  lastValue: string,
+  isPromptSelectorOpen: boolean
+): boolean =>
+  endsWithPromptTrigger(value) &&
+  lastValue !== value &&
+  !isPromptSelectorOpen
+
 export const shouldOpenPromptSelectorForInput = (
   event: InputEvent,
   value: string,
@@ -5,6 +17,4 @@ export const shouldOpenPromptSelectorForInput = (
   isPromptSelectorOpen: boolean
 ): boolean =>
   !event.isComposing &&
-  value.toLowerCase().endsWith('/p') &&
-  lastValue !== value &&
-  !isPromptSelectorOpen
+  shouldOpenPromptSelector(value, lastValue, isPromptSelectorOpen)

--- a/entrypoints/content/utils/promptTrigger.ts
+++ b/entrypoints/content/utils/promptTrigger.ts
@@ -1,0 +1,10 @@
+export const shouldOpenPromptSelectorForInput = (
+  event: InputEvent,
+  value: string,
+  lastValue: string,
+  isPromptSelectorOpen: boolean
+): boolean =>
+  !event.isComposing &&
+  value.toLowerCase().endsWith('/p') &&
+  lastValue !== value &&
+  !isPromptSelectorOpen

--- a/tests/content/promptTrigger.test.ts
+++ b/tests/content/promptTrigger.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldOpenPromptSelectorForInput } from '@/entrypoints/content/utils/promptTrigger'
+import {
+  shouldOpenPromptSelector,
+  shouldOpenPromptSelectorForInput,
+} from '@/entrypoints/content/utils/promptTrigger'
 
 const input = (isComposing: boolean): InputEvent =>
   new InputEvent('input', {
@@ -18,8 +21,14 @@ describe('content prompt trigger', () => {
     expect(shouldOpenPromptSelectorForInput(input(false), '/p', '/', false)).toBe(true)
   })
 
+  it('opens the selector after IME commit when the last tracked value was still /', () => {
+    expect(shouldOpenPromptSelector('/p', '/', false)).toBe(true)
+  })
+
   it('does not reopen for duplicate input or while the selector is open', () => {
     expect(shouldOpenPromptSelectorForInput(input(false), '/p', '/p', false)).toBe(false)
     expect(shouldOpenPromptSelectorForInput(input(false), '/p', '/', true)).toBe(false)
+    expect(shouldOpenPromptSelector('/p', '/p', false)).toBe(false)
+    expect(shouldOpenPromptSelector('/p', '/', true)).toBe(false)
   })
 })

--- a/tests/content/promptTrigger.test.ts
+++ b/tests/content/promptTrigger.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { shouldOpenPromptSelectorForInput } from '@/entrypoints/content/utils/promptTrigger'
+
+const input = (isComposing: boolean): InputEvent =>
+  new InputEvent('input', {
+    bubbles: true,
+    data: 'p',
+    inputType: 'insertText',
+    isComposing,
+  })
+
+describe('content prompt trigger', () => {
+  it('does not open the selector for composing /p input', () => {
+    expect(shouldOpenPromptSelectorForInput(input(true), '/p', '/', false)).toBe(false)
+  })
+
+  it('opens the selector for committed /p input', () => {
+    expect(shouldOpenPromptSelectorForInput(input(false), '/p', '/', false)).toBe(true)
+  })
+
+  it('does not reopen for duplicate input or while the selector is open', () => {
+    expect(shouldOpenPromptSelectorForInput(input(false), '/p', '/p', false)).toBe(false)
+    expect(shouldOpenPromptSelectorForInput(input(false), '/p', '/', true)).toBe(false)
+  })
+})


### PR DESCRIPTION
Typing `/p` with a Chinese IME in Edge can open the selector before composition is committed, leaving an extra `p` in the page. The selector now waits for a committed `/p`, while the normal English trigger stays unchanged. I added focused coverage for composing and committed input; those cases pass. Fixes #33
